### PR TITLE
[#18] Hub 및 HubRoute에 QueryDSL을 적용한 Search 기능 구현

### DIFF
--- a/logistic-service/build.gradle
+++ b/logistic-service/build.gradle
@@ -32,6 +32,13 @@ dependencies {
 
 	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
 
+	// querydsl
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation 'org.jetbrains:annotations:24.1.0'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/config/QueryDslConfig.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.sparta.blackyolk.logistic_service.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jPAQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/config/WebConfig.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.sparta.blackyolk.logistic_service.common.config;
+
+import com.sparta.blackyolk.logistic_service.common.pagenation.PaginationArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final PaginationArgumentResolver paginationArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(paginationArgumentResolver);
+    }
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/pagenation/PaginationArgumentResolver.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/pagenation/PaginationArgumentResolver.java
@@ -1,0 +1,57 @@
+package com.sparta.blackyolk.logistic_service.common.pagenation;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class PaginationArgumentResolver extends PageableHandlerMethodArgumentResolver {
+
+    @Override
+    public Pageable resolveArgument(
+        MethodParameter methodParameter,
+        ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory
+    ) {
+        Pageable pageable = super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+
+        if (methodParameter.hasMethodAnnotation(PaginationConstraint.class)) {
+            return validatePageableOrDefault(methodParameter, pageable);
+        }
+
+        return pageable;
+    }
+
+    private Pageable validatePageableOrDefault(MethodParameter methodParameter, Pageable pageable) {
+        PaginationConstraint constraint = methodParameter.getMethodAnnotation(PaginationConstraint.class);
+
+        Sort sort = resolveSortOrDefault(pageable, constraint);
+        int size = resolveSizeOrDefault(pageable, constraint);
+
+        return PageRequest.of(pageable.getPageNumber(), size, sort);
+    }
+
+    private Sort resolveSortOrDefault(Pageable pageable, PaginationConstraint constraint) {
+        if (pageable.getSort().isSorted()) {
+            return pageable.getSort();
+        }
+        return Sort.by(Sort.Direction.fromString(constraint.defaultDirection()), constraint.defaultSort());
+    }
+
+    private int resolveSizeOrDefault(Pageable pageable, PaginationConstraint constraint) {
+        int requestedSize = pageable.getPageSize();
+        for (int availableSize : constraint.availableSize()) {
+            if (requestedSize == availableSize) {
+                return requestedSize;
+            }
+        }
+        return constraint.defaultSize();
+    }
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/pagenation/PaginationConstraint.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/pagenation/PaginationConstraint.java
@@ -1,0 +1,15 @@
+package com.sparta.blackyolk.logistic_service.common.pagenation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface PaginationConstraint {
+    int[] availableSize() default {10, 30, 50};
+    int defaultSize() default 10;
+    String defaultSort() default "createdAt";
+    String defaultDirection() default "DESC";
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/adapter/HubPersistenceAdapter.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/adapter/HubPersistenceAdapter.java
@@ -5,6 +5,7 @@ import com.sparta.blackyolk.logistic_service.hub.application.domain.HubForCreate
 import com.sparta.blackyolk.logistic_service.hub.application.domain.HubForDelete;
 import com.sparta.blackyolk.logistic_service.hub.application.domain.HubForUpdate;
 import com.sparta.blackyolk.logistic_service.hub.application.port.HubPersistencePort;
+import com.sparta.blackyolk.logistic_service.hub.framework.repository.HubReadOnlyRepository;
 import com.sparta.blackyolk.logistic_service.hub.framework.repository.HubRepository;
 import com.sparta.blackyolk.logistic_service.hub.data.HubEntity;
 import java.math.BigDecimal;
@@ -12,6 +13,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,18 +23,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class HubPersistenceAdapter implements HubPersistencePort {
 
     private final HubRepository hubRepository;
+    private final HubReadOnlyRepository hubReadOnlyRepository;
 
     public Optional<Hub> findByHubId(String hubId) {
-        return hubRepository.findByHubIdAndIsDeletedFalse(hubId)
+        return hubReadOnlyRepository.findByHubIdAndIsDeletedFalse(hubId)
             .map(HubEntity::toDomain)
             .or(Optional::empty);
     }
 
     public List<Hub> findHubsByIds(List<String> hubIds) {
-        return hubRepository.findByHubIdsAndIsDeletedFalse(hubIds)
+        return hubReadOnlyRepository.findByHubIdsAndIsDeletedFalse(hubIds)
             .stream()
             .map(HubEntity::toDomain)
             .collect(Collectors.toList());
+    }
+
+    public Page<HubEntity> findAllHubs(String keyword, Pageable pageable) {
+        return hubReadOnlyRepository.findAllHubsAndIsDeletedFalseWithKeyword(keyword, pageable);
     }
 
     @Override
@@ -43,7 +51,7 @@ public class HubPersistenceAdapter implements HubPersistencePort {
     @Override
     public Hub updateHub(HubForUpdate hubForUpdate, BigDecimal axisX, BigDecimal axisY) {
 
-        HubEntity hubEntity = hubRepository.findByHubIdAndIsDeletedFalse(hubForUpdate.hubId()).get();
+        HubEntity hubEntity = hubReadOnlyRepository.findByHubIdAndIsDeletedFalse(hubForUpdate.hubId()).get();
         hubEntity.updateHub(hubForUpdate, axisX, axisY);
 
         return hubEntity.toDomain();
@@ -53,7 +61,7 @@ public class HubPersistenceAdapter implements HubPersistencePort {
     @Override
     public Hub deleteHub(HubForDelete hubForDelete) {
 
-        HubEntity hubEntity = hubRepository.findByHubIdAndIsDeletedFalse(hubForDelete.hubId()).get();
+        HubEntity hubEntity = hubReadOnlyRepository.findByHubIdAndIsDeletedFalse(hubForDelete.hubId()).get();
         hubEntity.deleteHub(hubForDelete);
 
         return hubEntity.toDomain();

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/adapter/HubPersistenceAdapter.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/adapter/HubPersistenceAdapter.java
@@ -25,12 +25,14 @@ public class HubPersistenceAdapter implements HubPersistencePort {
     private final HubRepository hubRepository;
     private final HubReadOnlyRepository hubReadOnlyRepository;
 
+    @Transactional(readOnly = true)
     public Optional<Hub> findByHubId(String hubId) {
         return hubReadOnlyRepository.findByHubIdAndIsDeletedFalse(hubId)
             .map(HubEntity::toDomain)
             .or(Optional::empty);
     }
 
+    @Transactional(readOnly = true)
     public List<Hub> findHubsByIds(List<String> hubIds) {
         return hubReadOnlyRepository.findByHubIdsAndIsDeletedFalse(hubIds)
             .stream()
@@ -38,7 +40,8 @@ public class HubPersistenceAdapter implements HubPersistencePort {
             .collect(Collectors.toList());
     }
 
-    public Page<HubEntity> findAllHubs(String keyword, Pageable pageable) {
+    @Transactional(readOnly = true)
+    public Page<HubEntity> findAllHubsWithKeyword(String keyword, Pageable pageable) {
         return hubReadOnlyRepository.findAllHubsAndIsDeletedFalseWithKeyword(keyword, pageable);
     }
 

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/repository/HubReadOnlyReadOnlyRepositoryImpl.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/repository/HubReadOnlyReadOnlyRepositoryImpl.java
@@ -68,7 +68,15 @@ public class HubReadOnlyReadOnlyRepositoryImpl implements HubReadOnlyRepository 
     select h
     from HubEntity h
     where h.isDeleted = false
-      and (h.hubName like concat('%', :keyword, '%') or :keyword is null)
+      and (
+          lower(h.hubName) like concat('%', :keyword, '%') or
+          lower(h.hubAddress.sido) like concat('%', :keyword, '%') or
+          lower(h.hubAddress.sigungu) like concat('%', :keyword, '%') or
+          lower(h.hubAddress.eupmyun) like concat('%', :keyword, '%') or
+          lower(h.hubAddress.roadName) like concat('%', :keyword, '%') or
+          lower(h.hubAddress.buildingNumber) like concat('%', :keyword, '%') or
+          lower(h.hubAddress.zipCode) like concat('%', :keyword, '%')
+      )
     order by h.createdAt desc
 
     select count(h)

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/repository/HubReadOnlyReadOnlyRepositoryImpl.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/repository/HubReadOnlyReadOnlyRepositoryImpl.java
@@ -1,0 +1,141 @@
+package com.sparta.blackyolk.logistic_service.hub.framework.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.blackyolk.logistic_service.hub.data.HubEntity;
+import com.sparta.blackyolk.logistic_service.hub.data.QHubEntity;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class HubReadOnlyReadOnlyRepositoryImpl implements HubReadOnlyRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QHubEntity hubEntity = QHubEntity.hubEntity;
+
+    /*
+    select h from HubEntity h where h.hubId = :hubId and h.isDeleted = false
+    */
+    @Override
+    public Optional<HubEntity> findByHubIdAndIsDeletedFalse(String hubId) {
+
+        BooleanExpression isHubIdEquals = hubEntity.hubId.eq(hubId);
+        BooleanExpression isNotDeleted = hubEntity.isDeleted.isFalse();
+
+        HubEntity result = jpaQueryFactory.selectFrom(hubEntity)
+            .where(isHubIdEquals.and(isNotDeleted))
+            .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
+    /*
+    select distinct h from HubEntity h where h.hubId in :hubIds and h.isDeleted = false
+    */
+    @Override
+    public List<HubEntity> findByHubIdsAndIsDeletedFalse(List<String> hubIds) {
+        return jpaQueryFactory
+            .selectFrom(hubEntity)
+            .where(buildConditions(hubIds))
+            .fetch();
+    }
+
+    private BooleanBuilder buildConditions(List<String> hubIds) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (hubIds != null && !hubIds.isEmpty()) {
+            builder.and(hubEntity.hubId.in(hubIds));
+        }
+
+        builder.and(hubEntity.isDeleted.isFalse());
+
+        return builder;
+    }
+
+    /*
+    select h
+    from HubEntity h
+    where h.isDeleted = false
+      and (h.hubName like concat('%', :keyword, '%') or :keyword is null)
+    order by h.createdAt desc
+
+    select count(h)
+    from HubEntity h
+    where h.isDeleted = false
+      and (h.hubName like concat('%', :keyword, '%') or :keyword is null)
+    */
+    @Override
+    public Page<HubEntity> findAllHubsAndIsDeletedFalseWithKeyword(
+        String keyword,
+        Pageable pageable
+    ) {
+
+        BooleanBuilder builder = buildKeywordSearchConditions(keyword);
+
+        List<OrderSpecifier<?>> orderSpecifiers = pageable.getSort().stream()
+            .map(order -> mapToOrderSpecifier(order.getProperty(), order.isAscending()))
+            .collect(Collectors.toList());
+
+        List<HubEntity> results = jpaQueryFactory.selectFrom(hubEntity)
+            .where(builder)
+            .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        Long totalCount = jpaQueryFactory.select(hubEntity.count())
+            .from(hubEntity)
+            .where(builder)
+            .fetchOne();
+
+        long total = (totalCount != null) ? totalCount : 0L;
+
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    private BooleanBuilder buildKeywordSearchConditions(String keyword) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(hubEntity.isDeleted.isFalse());
+
+        if (keyword != null && !keyword.isBlank()) {
+            String trimmedKeyword = keyword.trim();
+
+            // 여러 필드에 대한 검색 조건 추가
+            builder.and(
+                hubEntity.hubName.containsIgnoreCase(trimmedKeyword)
+                    .or(hubEntity.hubAddress.sido.containsIgnoreCase(trimmedKeyword))
+                    .or(hubEntity.hubAddress.sigungu.containsIgnoreCase(trimmedKeyword))
+                    .or(hubEntity.hubAddress.eupmyun.containsIgnoreCase(trimmedKeyword))
+                    .or(hubEntity.hubAddress.roadName.containsIgnoreCase(trimmedKeyword))
+                    .or(hubEntity.hubAddress.buildingNumber.containsIgnoreCase(trimmedKeyword))
+                    .or(hubEntity.hubAddress.zipCode.containsIgnoreCase(trimmedKeyword))
+            );
+        }
+
+        return builder;
+    }
+
+    private OrderSpecifier<?> mapToOrderSpecifier(String sortProperty, boolean ascending) {
+
+        log.info("[Hub QueryDSL] Applying sort: {} ascending: {}", sortProperty, ascending);
+
+        return switch (sortProperty) {
+            case "createdAt" -> ascending ? hubEntity.createdAt.asc() : hubEntity.createdAt.desc();
+            case "updatedAt" -> ascending ? hubEntity.updatedAt.asc() : hubEntity.updatedAt.desc();
+            default -> hubEntity.createdAt.desc();
+        };
+    }
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/repository/HubReadOnlyRepository.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/repository/HubReadOnlyRepository.java
@@ -1,0 +1,14 @@
+package com.sparta.blackyolk.logistic_service.hub.framework.repository;
+
+import com.sparta.blackyolk.logistic_service.hub.data.HubEntity;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface HubReadOnlyRepository {
+
+    Optional<HubEntity> findByHubIdAndIsDeletedFalse(String hubId);
+    List<HubEntity> findByHubIdsAndIsDeletedFalse(List<String> hubIds);
+    Page<HubEntity> findAllHubsAndIsDeletedFalseWithKeyword(String keyword, Pageable pageable);
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/repository/HubRepository.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/repository/HubRepository.java
@@ -1,17 +1,8 @@
 package com.sparta.blackyolk.logistic_service.hub.framework.repository;
 
 import com.sparta.blackyolk.logistic_service.hub.data.HubEntity;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface HubRepository extends JpaRepository<HubEntity, String> {
 
-    @Query("select h from HubEntity h where h.hubId = :hubId and h.isDeleted = false")
-    Optional<HubEntity> findByHubIdAndIsDeletedFalse(@Param("hubId") String hubId);
-
-    @Query("select distinct h from HubEntity h where h.hubId in :hubIds and h.isDeleted = false")
-    List<HubEntity> findByHubIdsAndIsDeletedFalse(List<String> hubIds);
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/controller/HubQueryController.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/controller/HubQueryController.java
@@ -1,15 +1,22 @@
 package com.sparta.blackyolk.logistic_service.hub.framework.web.controller;
 
+import com.sparta.blackyolk.logistic_service.common.pagenation.PaginationConstraint;
 import com.sparta.blackyolk.logistic_service.hub.application.domain.Hub;
 import com.sparta.blackyolk.logistic_service.hub.application.domain.HubForRead;
 import com.sparta.blackyolk.logistic_service.hub.application.usecase.HubUseCase;
+import com.sparta.blackyolk.logistic_service.hub.data.HubEntity;
+import com.sparta.blackyolk.logistic_service.hub.framework.adapter.HubPersistenceAdapter;
 import com.sparta.blackyolk.logistic_service.hub.framework.web.dto.HubGetResponse;
+import com.sparta.blackyolk.logistic_service.hub.framework.web.dto.HubPageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class HubQueryController {
 
     private final HubUseCase hubUseCase;
+    private final HubPersistenceAdapter hubPersistenceAdapter;
 
     // TODO : 지우기
     private final Long TEST_USER = 1L;
@@ -39,4 +47,18 @@ public class HubQueryController {
         return HubGetResponse.toDTO(hub);
     }
 
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping
+    @PaginationConstraint(defaultSort = "createdAt", defaultDirection = "DESC", availableSize = {10,30,50}, defaultSize = 10)
+    public HubPageResponse getHubs(
+        Pageable pageable,
+        @RequestParam(required = false) String keyword
+    ) {
+        // TODO : user token, user role 받아야 하나?
+        log.info("[Hub search 조회 pageable] : {}", pageable);
+
+        Page<HubEntity> hubPage = hubPersistenceAdapter.findAllHubs(keyword, pageable);
+
+        return new HubPageResponse(hubPage);
+    }
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/controller/HubQueryController.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/controller/HubQueryController.java
@@ -57,7 +57,7 @@ public class HubQueryController {
         // TODO : user token, user role 받아야 하나?
         log.info("[Hub search 조회 pageable] : {}", pageable);
 
-        Page<HubEntity> hubPage = hubPersistenceAdapter.findAllHubs(keyword, pageable);
+        Page<HubEntity> hubPage = hubPersistenceAdapter.findAllHubsWithKeyword(keyword, pageable);
 
         return new HubPageResponse(hubPage);
     }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubPageResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubPageResponse.java
@@ -1,0 +1,61 @@
+package com.sparta.blackyolk.logistic_service.hub.framework.web.dto;
+
+import com.sparta.blackyolk.logistic_service.hub.data.HubEntity;
+import com.sparta.blackyolk.logistic_service.hub.data.vo.HubStatus;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record HubPageResponse(
+    PageInfo page,
+    List<HubResponse> hubs
+) {
+
+    public HubPageResponse(
+        Page<HubEntity> hubPage
+    ) {
+        this(
+            new PageInfo(
+                hubPage.getNumber(),
+                hubPage.getSize(),
+                hubPage.getTotalElements(),
+                hubPage.getTotalPages()
+            ),
+            HubResponse.toDTO(hubPage.getContent())
+        );
+    }
+
+    public record HubResponse(
+        String id,
+        Long hubManagerId,
+        String name,
+        HubStatus status,
+        HubCoordinateResponse coordinate,
+        HubAddressResponse address
+    ) {
+        public static List<HubResponse> toDTO(List<HubEntity> hubEntityList) {
+            return hubEntityList.stream()
+                .map(HubResponse::toDTO)
+                .toList();
+        }
+
+        public static HubResponse toDTO(HubEntity hubEntity) {
+            return new HubResponse(
+                hubEntity.getHubId(),
+                hubEntity.getHubManagerId(),
+                hubEntity.getHubName(),
+                hubEntity.getStatus(),
+                HubCoordinateResponse.fromDomain(hubEntity.getHubCoordinate().toDomain()),
+                HubAddressResponse.fromDomain(hubEntity.getHubAddress().toDomain())
+            );
+        }
+    }
+
+    public record PageInfo(
+        int current,
+        int size,
+        long totalElements,
+        int totalPages
+    ) {
+
+    }
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/adapter/HubRoutePersistenceAdapter.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/adapter/HubRoutePersistenceAdapter.java
@@ -3,17 +3,19 @@ package com.sparta.blackyolk.logistic_service.hubroute.framework.adapter;
 import com.sparta.blackyolk.logistic_service.hub.application.domain.Hub;
 import com.sparta.blackyolk.logistic_service.hub.data.HubEntity;
 import com.sparta.blackyolk.logistic_service.hub.framework.repository.HubReadOnlyRepository;
-import com.sparta.blackyolk.logistic_service.hub.framework.repository.HubRepository;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRoute;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRouteForDelete;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRouteForUpdate;
 import com.sparta.blackyolk.logistic_service.hubroute.application.port.HubRoutePersistencePort;
 import com.sparta.blackyolk.logistic_service.hubroute.data.HubRouteEntity;
+import com.sparta.blackyolk.logistic_service.hubroute.framework.repository.HubRouteReadOnlyRepository;
 import com.sparta.blackyolk.logistic_service.hubroute.framework.repository.HubRouteRepository;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,13 +24,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class HubRoutePersistenceAdapter implements HubRoutePersistencePort {
 
     private final HubRouteRepository hubRouteRepository;
-    private final HubRepository hubRepository;
     private final HubReadOnlyRepository hubReadOnlyRepository;
+    private final HubRouteReadOnlyRepository hubRouteReadOnlyRepository;
 
+    @Transactional(readOnly = true)
     public Optional<HubRoute> findByHubRouteId(String hubRouteId) {
-        return hubRouteRepository.findByHubRouteIdAndIsDeletedFalse(hubRouteId)
+        return hubRouteReadOnlyRepository.findByHubRouteIdAndIsDeletedFalse(hubRouteId)
             .map(HubRouteEntity::toDomain)
             .or(Optional::empty);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<HubRouteEntity> findAllHubRoutesByHubIdWithKeyword(String hubId, String keyword, Pageable pageable) {
+        return hubRouteReadOnlyRepository.findAllHubRoutesByHubIdAndIsDeletedFalseWithKeyword(
+            hubId,
+            keyword,
+            pageable
+        );
     }
 
     @Transactional
@@ -59,7 +71,7 @@ public class HubRoutePersistenceAdapter implements HubRoutePersistencePort {
     @Override
     public HubRoute updateHubRoute(HubRouteForUpdate hubRouteForUpdate, Hub arrivalHub, BigDecimal distance, Integer duration) {
 
-        HubRouteEntity hubRouteEntity = hubRouteRepository.findByHubRouteIdAndIsDeletedFalse(hubRouteForUpdate.hubRouteId()).get();
+        HubRouteEntity hubRouteEntity = hubRouteReadOnlyRepository.findByHubRouteIdAndIsDeletedFalse(hubRouteForUpdate.hubRouteId()).get();
         HubEntity arrivalHubEntity = arrivalHub != null ?
         hubReadOnlyRepository.findByHubIdAndIsDeletedFalse(hubRouteForUpdate.arrivalHubId()).get() : null;
 
@@ -72,7 +84,7 @@ public class HubRoutePersistenceAdapter implements HubRoutePersistencePort {
     @Override
     public HubRoute deleteHubRoute(HubRouteForDelete hubRouteForDelete) {
 
-        HubRouteEntity hubRouteEntity = hubRouteRepository.findByHubRouteIdAndIsDeletedFalse(hubRouteForDelete.hubRouteId()).get();
+        HubRouteEntity hubRouteEntity = hubRouteReadOnlyRepository.findByHubRouteIdAndIsDeletedFalse(hubRouteForDelete.hubRouteId()).get();
         hubRouteEntity.delete(hubRouteForDelete);
 
         return hubRouteEntity.toDomain();

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/adapter/HubRoutePersistenceAdapter.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/adapter/HubRoutePersistenceAdapter.java
@@ -2,6 +2,7 @@ package com.sparta.blackyolk.logistic_service.hubroute.framework.adapter;
 
 import com.sparta.blackyolk.logistic_service.hub.application.domain.Hub;
 import com.sparta.blackyolk.logistic_service.hub.data.HubEntity;
+import com.sparta.blackyolk.logistic_service.hub.framework.repository.HubReadOnlyRepository;
 import com.sparta.blackyolk.logistic_service.hub.framework.repository.HubRepository;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRoute;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRouteForDelete;
@@ -22,6 +23,7 @@ public class HubRoutePersistenceAdapter implements HubRoutePersistencePort {
 
     private final HubRouteRepository hubRouteRepository;
     private final HubRepository hubRepository;
+    private final HubReadOnlyRepository hubReadOnlyRepository;
 
     public Optional<HubRoute> findByHubRouteId(String hubRouteId) {
         return hubRouteRepository.findByHubRouteIdAndIsDeletedFalse(hubRouteId)
@@ -33,7 +35,7 @@ public class HubRoutePersistenceAdapter implements HubRoutePersistencePort {
     @Override
     public HubRoute createHubRoute(Long userId, HubRoute hubRoute) {
 
-        List<HubEntity> hubEntities = hubRepository.findByHubIdsAndIsDeletedFalse(
+        List<HubEntity> hubEntities = hubReadOnlyRepository.findByHubIdsAndIsDeletedFalse(
             List.of(hubRoute.getDepartureHub().getHubId(), hubRoute.getArrivalHub().getHubId())
         );
 
@@ -59,7 +61,7 @@ public class HubRoutePersistenceAdapter implements HubRoutePersistencePort {
 
         HubRouteEntity hubRouteEntity = hubRouteRepository.findByHubRouteIdAndIsDeletedFalse(hubRouteForUpdate.hubRouteId()).get();
         HubEntity arrivalHubEntity = arrivalHub != null ?
-        hubRepository.findByHubIdAndIsDeletedFalse(hubRouteForUpdate.arrivalHubId()).get() : null;
+        hubReadOnlyRepository.findByHubIdAndIsDeletedFalse(hubRouteForUpdate.arrivalHubId()).get() : null;
 
         hubRouteEntity.update(hubRouteForUpdate, arrivalHubEntity, distance, duration);
 

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/repository/HubRouteReadOnlyRepository.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/repository/HubRouteReadOnlyRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.blackyolk.logistic_service.hubroute.framework.repository;
+
+import com.sparta.blackyolk.logistic_service.hubroute.data.HubRouteEntity;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface HubRouteReadOnlyRepository {
+    Optional<HubRouteEntity> findByHubRouteIdAndIsDeletedFalse(String hubRouteId);
+    Page<HubRouteEntity> findAllHubRoutesByHubIdAndIsDeletedFalseWithKeyword(String hubId, String keyword, Pageable pageable);
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/repository/HubRouteReadOnlyRepositoryImpl.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/repository/HubRouteReadOnlyRepositoryImpl.java
@@ -1,0 +1,148 @@
+package com.sparta.blackyolk.logistic_service.hubroute.framework.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.blackyolk.logistic_service.hub.data.QHubEntity;
+import com.sparta.blackyolk.logistic_service.hubroute.data.HubRouteEntity;
+import com.sparta.blackyolk.logistic_service.hubroute.data.QHubRouteEntity;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class HubRouteReadOnlyRepositoryImpl implements HubRouteReadOnlyRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QHubRouteEntity hubRouteEntity = QHubRouteEntity.hubRouteEntity;
+
+    /*
+    select hr from
+    HubRouteEntity hr
+    join fetch hr.departureHub
+    join fetch hr.arrivalHub
+    where hr.hubRouteId = :hubRouteId
+      and hr.isDeleted = false
+    * */
+    @Override
+    public Optional<HubRouteEntity> findByHubRouteIdAndIsDeletedFalse(String hubRouteId) {
+
+        QHubEntity departureHub =  new QHubEntity("departureHub");
+        QHubEntity arrivalHub = new QHubEntity("arrivalHub");
+
+        BooleanExpression isHubRouteIdEquals = hubRouteEntity.hubRouteId.eq(hubRouteId);
+        BooleanExpression isDeleted = hubRouteEntity.isDeleted.eq(false);
+
+        HubRouteEntity result = jpaQueryFactory.selectFrom(hubRouteEntity)
+            .join(hubRouteEntity.departureHub, departureHub).fetchJoin()
+            .join(hubRouteEntity.arrivalHub, arrivalHub).fetchJoin()
+            .where(isHubRouteIdEquals.and(isDeleted))
+            .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
+    /*
+    select hr.*
+    from hub_route_entity hr
+    where hr.is_deleted = false
+      and (hr.departure_hub_id = :hubId or hr.arrival_hub_id = :hubId)
+      and (
+          lower(hr.departure_hub_name) like concat('%', lower(:keyword), '%') or
+          lower(hr.departure_hub_address_sido) like concat('%', lower(:keyword), '%') or
+          lower(hr.departure_hub_address_sigungu) like concat('%', lower(:keyword), '%') or
+          lower(hr.departure_hub_address_eupmyun) like concat('%', lower(:keyword), '%') or
+          lower(hr.departure_hub_address_road_name) like concat('%', lower(:keyword), '%') or
+          lower(hr.departure_hub_address_building_number) like concat('%', lower(:keyword), '%') or
+          lower(hr.departure_hub_address_zip_code) like concat('%', lower(:keyword), '%')
+      )
+    order by hr.created_at desc
+    limit :limit offset :offset;
+
+    select count(*)
+    from hub_route_entity hr
+    where hr.is_deleted = false
+      and (hr.departure_hub_id = :hubId
+           or hr.arrival_hub_id = :hubId)
+      and (:keyword is null
+           or lower(hr.keyword) like concat('%', lower(:keyword), '%'));
+    */
+    @Override
+    public Page<HubRouteEntity> findAllHubRoutesByHubIdAndIsDeletedFalseWithKeyword(
+        String hubId,
+        String keyword,
+        Pageable pageable
+    ) {
+
+        BooleanBuilder builder = buildKeywordSearchConditions(hubId, keyword);
+
+        List<OrderSpecifier<?>> orderSpecifiers = pageable.getSort().stream()
+            .map(order -> mapToOrderSpecifier(order.getProperty(), order.isAscending()))
+            .collect(Collectors.toList());
+
+        List<HubRouteEntity> results = jpaQueryFactory.selectFrom(hubRouteEntity)
+            .join(hubRouteEntity.departureHub).fetchJoin()
+            .join(hubRouteEntity.arrivalHub).fetchJoin()
+            .where(builder)
+            .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        Long totalCount = jpaQueryFactory.select(hubRouteEntity.count())
+            .from(hubRouteEntity)
+            .where(builder)
+            .fetchOne();
+
+        long total = (totalCount != null) ? totalCount : 0L;
+
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    private BooleanBuilder buildKeywordSearchConditions(String hubId, String keyword) {
+
+        BooleanExpression isHubIdEquals = hubRouteEntity.departureHub.hubId.eq(hubId);
+        BooleanExpression isDeleted = hubRouteEntity.isDeleted.eq(false);
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(isDeleted);
+        builder.and(isHubIdEquals);
+
+        if (keyword != null && !keyword.isBlank()) {
+            String trimmedKeyword = keyword.trim();
+
+            // 여러 필드에 대한 검색 조건 추가
+            builder.and(
+                hubRouteEntity.arrivalHub.hubName.containsIgnoreCase(trimmedKeyword)
+                    .or(hubRouteEntity.arrivalHub.hubAddress.sido.containsIgnoreCase(trimmedKeyword))
+                    .or(hubRouteEntity.arrivalHub.hubAddress.sigungu.containsIgnoreCase(trimmedKeyword))
+                    .or(hubRouteEntity.arrivalHub.hubAddress.eupmyun.containsIgnoreCase(trimmedKeyword))
+                    .or(hubRouteEntity.arrivalHub.hubAddress.roadName.containsIgnoreCase(trimmedKeyword))
+                    .or(hubRouteEntity.arrivalHub.hubAddress.buildingNumber.containsIgnoreCase(trimmedKeyword))
+                    .or(hubRouteEntity.arrivalHub.hubAddress.zipCode.containsIgnoreCase(trimmedKeyword))
+            );
+        }
+
+        return builder;
+    }
+
+    private OrderSpecifier<?> mapToOrderSpecifier(String sortProperty, boolean ascending) {
+
+        log.info("[HubRoute QueryDSL] Applying sort: {} ascending: {}", sortProperty, ascending);
+
+        return switch (sortProperty) {
+            case "createdAt" -> ascending ? hubRouteEntity.createdAt.asc() : hubRouteEntity.createdAt.desc();
+            case "updatedAt" -> ascending ? hubRouteEntity.updatedAt.asc() : hubRouteEntity.updatedAt.desc();
+            default -> hubRouteEntity.createdAt.desc();
+        };
+    }
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/repository/HubRouteRepository.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/repository/HubRouteRepository.java
@@ -1,16 +1,8 @@
 package com.sparta.blackyolk.logistic_service.hubroute.framework.repository;
 
 import com.sparta.blackyolk.logistic_service.hubroute.data.HubRouteEntity;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface HubRouteRepository extends JpaRepository<HubRouteEntity, String> {
 
-    @Query("select hr from HubRouteEntity hr "
-        + "join fetch hr.departureHub "
-        + "join fetch hr.arrivalHub "
-        + "where hr.hubRouteId = :hubRouteId and hr.isDeleted = false")
-    Optional<HubRouteEntity> findByHubRouteIdAndIsDeletedFalse(@Param("hubRouteId")String hubRouteId);
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/controller/HubRouteQueryController.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/controller/HubRouteQueryController.java
@@ -1,15 +1,22 @@
 package com.sparta.blackyolk.logistic_service.hubroute.framework.web.controller;
 
+import com.sparta.blackyolk.logistic_service.common.pagenation.PaginationConstraint;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRoute;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRouteForRead;
 import com.sparta.blackyolk.logistic_service.hubroute.application.usecase.HubRouteUseCase;
+import com.sparta.blackyolk.logistic_service.hubroute.data.HubRouteEntity;
+import com.sparta.blackyolk.logistic_service.hubroute.framework.adapter.HubRoutePersistenceAdapter;
 import com.sparta.blackyolk.logistic_service.hubroute.framework.web.dto.HubRouteGetResponse;
+import com.sparta.blackyolk.logistic_service.hubroute.framework.web.dto.HubRoutePageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,13 +27,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class HubRouteQueryController {
 
     private final HubRouteUseCase hubRouteUseCase;
+    private final HubRoutePersistenceAdapter hubRoutePersistenceAdapter;
 
     // TODO : 지우기
     private final Long TEST_USER = 1L;
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{hubRouteId}")
-    public HubRouteGetResponse getHub(
+    public HubRouteGetResponse getHubRoute(
         @PathVariable(value = "hubId") String hubId,
         @PathVariable(value = "hubRouteId") String hubRouteId
     ) {
@@ -39,6 +47,26 @@ public class HubRouteQueryController {
         HubRoute hubRoute = hubRouteUseCase.getHubRoute(hubRouteForRead);
 
         return HubRouteGetResponse.toDTO(hubRoute);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping
+    @PaginationConstraint(defaultSort = "createdAt", defaultDirection = "DESC", availableSize = {10,30,50}, defaultSize = 10)
+    public HubRoutePageResponse getHubRoutes(
+        @PathVariable(value = "hubId") String hubId,
+        Pageable pageable,
+        @RequestParam(required = false) String keyword
+    ) {
+        // TODO : user token, user role 받아야 하나?
+        log.info("[HubRoute search 조회 pageable] : {}", pageable);
+
+        Page<HubRouteEntity> hubRoutePage = hubRoutePersistenceAdapter.findAllHubRoutesByHubIdWithKeyword(
+            hubId,
+            keyword,
+            pageable
+        );
+
+        return new HubRoutePageResponse(hubRoutePage);
     }
 
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRoutePageResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRoutePageResponse.java
@@ -1,0 +1,64 @@
+package com.sparta.blackyolk.logistic_service.hubroute.framework.web.dto;
+
+import com.sparta.blackyolk.logistic_service.hubroute.data.HubRouteEntity;
+import com.sparta.blackyolk.logistic_service.hubroute.data.vo.HubRouteStatus;
+import java.math.BigDecimal;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record HubRoutePageResponse(
+    PageInfo page,
+    List<HubRouteResponse> hubRoutes
+) {
+
+    public HubRoutePageResponse(
+        Page<HubRouteEntity> hubRoutePage
+    ) {
+        this(
+            new PageInfo(
+                hubRoutePage.getNumber(),
+                hubRoutePage.getSize(),
+                hubRoutePage.getTotalElements(),
+                hubRoutePage.getTotalPages()
+            ),
+            HubRouteResponse.toDTO(hubRoutePage.getContent())
+        );
+    }
+
+    public record HubRouteResponse(
+        String hubRouteId,
+        String departureHubName,
+        String arrivalHubName,
+        HubRouteStatus hubRouteStatus,
+        BigDecimal distance,
+        Integer duration,
+        String timeSlot
+    ) {
+        public static List<HubRouteResponse> toDTO(List<HubRouteEntity> hubRouteEntityList) {
+            return hubRouteEntityList.stream()
+                .map(HubRouteResponse::toDTO)
+                .toList();
+        }
+
+        public static HubRouteResponse toDTO(HubRouteEntity hubRouteEntity) {
+            return new HubRouteResponse(
+                hubRouteEntity.getHubRouteId(),
+                hubRouteEntity.getDepartureHub().getHubName(),
+                hubRouteEntity.getArrivalHub().getHubName(),
+                hubRouteEntity.getStatus(),
+                hubRouteEntity.getDistance(),
+                hubRouteEntity.getDuration(),
+                hubRouteEntity.getTimeSlot()
+            );
+        }
+    }
+
+    public record PageInfo(
+        int current,
+        int size,
+        long totalElements,
+        int totalPages
+    ) {
+
+    }
+}

--- a/logistic-service/src/main/resources/application-dev.yml
+++ b/logistic-service/src/main/resources/application-dev.yml
@@ -28,6 +28,7 @@ spring:
       hibernate:
         format_sql: true
         hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_batch_fetch_size: 500
     open-in-view: false
 
 logging:


### PR DESCRIPTION
## 📝 작업 내용

> - Hub와 HubRoute에 search 기능을 구현합니다.
>   - query dsl을 적용하였습니다. 
>   - 페이지네이션을 위한 pageconstraint 어노테이션을 생성 및 적용하였습니다.
>   - 검색 키워드 (키워드와 관련한 모든 정보를 반환합니다.)
>     - 검색 범위는 이름과 지역 입니다.  

## #️⃣ 연관 이슈
- #18

resolved: #18