### PR TITLE
[#34] Hub 및 HubRoute 등록 시 지정된 Hub 만 등록할 수 있도록 변경

### DIFF
--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/domain/Hub.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/domain/Hub.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 public class Hub {
     private String hubId;
     private String hubName;
+    private String hubCenter;
     private HubStatus hubStatus;
     private HubCoordinate hubCoordinate;
     private HubAddress hubAddress;

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/domain/HubForCreate.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/domain/HubForCreate.java
@@ -5,6 +5,7 @@ public record HubForCreate(
     String role,
     Long hubManagerId,
     String name,
+    String center,
     String sido,
     String sigungu,
     String eupmyun,

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/port/HubPersistencePort.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/port/HubPersistencePort.java
@@ -14,4 +14,5 @@ public interface HubPersistencePort {
     List<Hub> findHubsByIds(List<String> hubIds);
     Hub updateHub(HubForUpdate hubForUpdate, BigDecimal axisX, BigDecimal axisY);
     Hub deleteHub(HubForDelete hubForDelete);
+    Optional<Hub> findByHubCenter(String hubCenter);
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/service/HubService.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/service/HubService.java
@@ -9,6 +9,7 @@ import com.sparta.blackyolk.logistic_service.hub.application.domain.HubForUpdate
 import com.sparta.blackyolk.logistic_service.hub.application.port.HubPersistencePort;
 import com.sparta.blackyolk.logistic_service.hub.application.usecase.HubUseCase;
 import java.math.BigDecimal;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -25,6 +26,7 @@ public class HubService implements HubUseCase {
 
         // TODO : hubManagerId 있으면 hubManagerId 검증하는 로직 필요
         validateMaster(hubForCreate.role());
+        validateHubCenter(hubForCreate.center());
 
         // TODO: 좌표 조회하는 로직
         String url = URL + ADDRESS;
@@ -76,6 +78,13 @@ public class HubService implements HubUseCase {
     private void validateMaster(String role) {
         if (!"MASTER".equals(role)) {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+    }
+
+    private void validateHubCenter(String center) {
+        Optional<Hub> hub = hubPersistencePort.findByHubCenter(center);
+        if (hub.isPresent()) {
+            throw new CustomException(ErrorCode.HUB_ALREADY_EXIST);
         }
     }
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/data/HubEntity.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/data/HubEntity.java
@@ -38,6 +38,9 @@ public class HubEntity extends BaseEntity {
     @Column(name = "hub_name", unique = true, nullable = false)
     private String hubName;
 
+    @Column(name = "hub_center", nullable = false)
+    private String hubCenter;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "hub_status", nullable = false)
     private HubStatus status = HubStatus.ACTIVE;
@@ -63,12 +66,14 @@ public class HubEntity extends BaseEntity {
         Long userId,
         Long hubManagerId,
         String hubName,
+        String hubCenter,
         HubCoordinateEmbeddable hubCoordinate,
         HubAddressEmbeddable hubAddress
     ) {
         super(userId, userId);
         this.hubManagerId = hubManagerId;
         this.hubName = hubName;
+        this.hubCenter = hubCenter;
         this.hubCoordinate = hubCoordinate;
         this.hubAddress = hubAddress;
     }
@@ -81,6 +86,7 @@ public class HubEntity extends BaseEntity {
         return HubEntity.builder()
             .userId(hubForCreate.userId())
             .hubName(hubForCreate.name())
+            .hubCenter(hubForCreate.center())
             .hubCoordinate(new HubCoordinateEmbeddable(axisX, axisY))
             .hubAddress(HubAddressEmbeddable.builder()
                 .sido(hubForCreate.sido())
@@ -99,6 +105,7 @@ public class HubEntity extends BaseEntity {
         return new Hub(
             this.hubId,
             this.hubName,
+            this.hubCenter,
             this.status,
             this.hubCoordinate.toDomain(),
             this.hubAddress.toDomain(),

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/adapter/HubPersistenceAdapter.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/adapter/HubPersistenceAdapter.java
@@ -41,6 +41,13 @@ public class HubPersistenceAdapter implements HubPersistencePort {
     }
 
     @Transactional(readOnly = true)
+    public Optional<Hub> findByHubCenter(String hubCenter) {
+        return hubReadOnlyRepository.findByHubCenterIsDeletedFalse(hubCenter)
+            .map(HubEntity::toDomain)
+            .or(Optional::empty);
+    }
+
+    @Transactional(readOnly = true)
     public Page<HubEntity> findAllHubsWithKeyword(String keyword, Pageable pageable) {
         return hubReadOnlyRepository.findAllHubsAndIsDeletedFalseWithKeyword(keyword, pageable);
     }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/repository/HubReadOnlyReadOnlyRepositoryImpl.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/repository/HubReadOnlyReadOnlyRepositoryImpl.java
@@ -65,6 +65,22 @@ public class HubReadOnlyReadOnlyRepositoryImpl implements HubReadOnlyRepository 
     }
 
     /*
+    select h from HubEntity h where h.hubCenter = :hubCenter and h.isDeleted = false
+    */
+    @Override
+    public Optional<HubEntity> findByHubCenterIsDeletedFalse(String hubCenter) {
+
+        BooleanExpression isHubCenterEquals = hubEntity.hubCenter.eq(hubCenter);
+        BooleanExpression isNotDeleted = hubEntity.isDeleted.isFalse();
+
+        HubEntity result = jpaQueryFactory.selectFrom(hubEntity)
+            .where(isHubCenterEquals.and(isNotDeleted))
+            .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
+    /*
     select h
     from HubEntity h
     where h.isDeleted = false

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/repository/HubReadOnlyRepository.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/repository/HubReadOnlyRepository.java
@@ -11,4 +11,5 @@ public interface HubReadOnlyRepository {
     Optional<HubEntity> findByHubIdAndIsDeletedFalse(String hubId);
     List<HubEntity> findByHubIdsAndIsDeletedFalse(List<String> hubIds);
     Page<HubEntity> findAllHubsAndIsDeletedFalseWithKeyword(String keyword, Pageable pageable);
+    Optional<HubEntity> findByHubCenterIsDeletedFalse(String hubCenter);
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubCreateRequest.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubCreateRequest.java
@@ -1,6 +1,7 @@
 package com.sparta.blackyolk.logistic_service.hub.framework.web.dto;
 
 import com.sparta.blackyolk.logistic_service.hub.application.domain.HubForCreate;
+import com.sparta.blackyolk.logistic_service.hub.framework.web.validation.ValidCenter;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 
@@ -10,6 +11,10 @@ public record HubCreateRequest(
 
     @NotBlank(message = "허브 명을 입력해주세요.")
     String name,
+
+    @NotBlank(message = "허브 센터를 입력해주세요.")
+    @ValidCenter
+    String center,
 
     @Valid
     HubAddressCreateRequest address
@@ -25,6 +30,7 @@ public record HubCreateRequest(
             role,
             hubCreateRequest.hubManagerId(),
             hubCreateRequest.name(),
+            hubCreateRequest.center(),
             hubCreateRequest.address().sido(),
             hubCreateRequest.address().sigungu(),
             hubCreateRequest.address().eupmyun(),

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubCreateResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubCreateResponse.java
@@ -7,6 +7,7 @@ public record HubCreateResponse(
     String id,
     Long hubManagerId,
     String name,
+    String center,
     HubStatus status,
     HubCoordinateResponse coordinate,
     HubAddressResponse address
@@ -17,6 +18,7 @@ public record HubCreateResponse(
             hub.getHubId(),
             hub.getHubManagerId(),
             hub.getHubName(),
+            hub.getHubCenter(),
             hub.getHubStatus(),
             HubCoordinateResponse.fromDomain(hub.getHubCoordinate()),
             HubAddressResponse.fromDomain(hub.getHubAddress())

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubGetResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubGetResponse.java
@@ -7,6 +7,7 @@ public record HubGetResponse(
     String id,
     Long hubManagerId,
     String name,
+    String center,
     HubStatus status,
     HubCoordinateResponse coordinate,
     HubAddressResponse address
@@ -17,6 +18,7 @@ public record HubGetResponse(
             hub.getHubId(),
             hub.getHubManagerId(),
             hub.getHubName(),
+            hub.getHubCenter(),
             hub.getHubStatus(),
             HubCoordinateResponse.fromDomain(hub.getHubCoordinate()),
             HubAddressResponse.fromDomain(hub.getHubAddress())

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubPageResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubPageResponse.java
@@ -28,6 +28,7 @@ public record HubPageResponse(
         String id,
         Long hubManagerId,
         String name,
+        String center,
         HubStatus status,
         HubCoordinateResponse coordinate,
         HubAddressResponse address
@@ -43,6 +44,7 @@ public record HubPageResponse(
                 hubEntity.getHubId(),
                 hubEntity.getHubManagerId(),
                 hubEntity.getHubName(),
+                hubEntity.getHubCenter(),
                 hubEntity.getStatus(),
                 HubCoordinateResponse.fromDomain(hubEntity.getHubCoordinate().toDomain()),
                 HubAddressResponse.fromDomain(hubEntity.getHubAddress().toDomain())

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubUpdateResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubUpdateResponse.java
@@ -7,6 +7,7 @@ public record HubUpdateResponse(
     String id,
     Long hubManagerId,
     String name,
+    String center,
     HubStatus status,
     HubCoordinateResponse coordinate,
     HubAddressResponse address
@@ -17,6 +18,7 @@ public record HubUpdateResponse(
             hub.getHubId(),
             hub.getHubManagerId(),
             hub.getHubName(),
+            hub.getHubCenter(),
             hub.getHubStatus(),
             HubCoordinateResponse.fromDomain(hub.getHubCoordinate()),
             HubAddressResponse.fromDomain(hub.getHubAddress())

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/validation/CenterValidator.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/validation/CenterValidator.java
@@ -1,0 +1,37 @@
+package com.sparta.blackyolk.logistic_service.hub.framework.web.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Set;
+
+public class CenterValidator implements ConstraintValidator<ValidCenter, String> {
+
+    // 허용된 센터 지역 목록
+    private static final Set<String> ALLOWED_CENTERS = Set.of(
+          "서울특별시 센터",
+          "경기 북부 센터",
+          "경기 남부 센터",
+          "부산광역시 센터",
+          "대구광역시 센터",
+          "인천광역시 센터",
+          "광주광역시 센터",
+          "대전광역시 센터",
+          "울산광역시 센터",
+          "세종특별자치시 센터",
+          "강원특별자치도 센터",
+          "충청북도 센터",
+          "충청남도 센터",
+          "전북특별자치도 센터",
+          "전라남도 센터",
+          "경상북도 센터",
+          "경상남도 센터"
+    );
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true; // null을 허용
+        }
+        return ALLOWED_CENTERS.contains(value);
+    }
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/validation/ValidCenter.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/validation/ValidCenter.java
@@ -1,0 +1,40 @@
+package com.sparta.blackyolk.logistic_service.hub.framework.web.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = CenterValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidCenter {
+
+    String message() default """
+        유효하지 않은 센터 지역입니다. 다음 지역 중 하나를 선택해주세요:
+          1. "서울특별시 센터",
+          2. "경기 북부 센터",
+          3. "경기 남부 센터",
+          4. "부산광역시 센터",
+          5. "대구광역시 센터",
+          6. "인천광역시 센터",
+          7. "광주광역시 센터",
+          8. "대전광역시 센터",
+          9. "울산광역시 센터",
+          10. "세종특별자치시 센터",
+          11. "강원특별자치도 센터",
+          12. "충청북도 센터",
+          13. "충청남도 센터",
+          14. "전북특별자치도 센터",
+          15. "전라남도 센터",
+          16. "경상북도 센터",
+          17. "경상남도 센터"
+        """;
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRouteForCreate.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRouteForCreate.java
@@ -5,6 +5,7 @@ public record HubRouteForCreate(
     String role,
     String departureHubId,
     String arrivalHubId,
+    String targetHubCenter,
     String timeSlot,
     double timeSlotWeight
 ) {

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRouteForUpdate.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRouteForUpdate.java
@@ -7,7 +7,6 @@ public record HubRouteForUpdate(
     String role,
     String hubRouteId,
     String departureHubId,
-    String arrivalHubId,
     String timeSlot,
     Double timeSlotWeight, // timeslot이 없으면 null 처리를 할 수 있도록 Double로 설정,
     HubRouteStatus status

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/port/HubRoutePersistencePort.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/port/HubRoutePersistencePort.java
@@ -1,15 +1,13 @@
 package com.sparta.blackyolk.logistic_service.hubroute.application.port;
 
-import com.sparta.blackyolk.logistic_service.hub.application.domain.Hub;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRoute;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRouteForDelete;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRouteForUpdate;
-import java.math.BigDecimal;
 import java.util.Optional;
 
 public interface HubRoutePersistencePort {
     HubRoute createHubRoute(Long userId, HubRoute hubRoute);
     Optional<HubRoute> findByHubRouteId(String hubRouteId);
-    HubRoute updateHubRoute(HubRouteForUpdate hubRouteForUpdate, Hub arrivalHub, BigDecimal distance, Integer duration);
+    HubRoute updateHubRoute(HubRouteForUpdate hubRouteForUpdate);
     HubRoute deleteHubRoute(HubRouteForDelete hubRouteForDelete);
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/service/HubRouteService.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/service/HubRouteService.java
@@ -86,27 +86,7 @@ public class HubRouteService implements HubRouteUseCase {
         HubRoute hubRoute = validateHubRoute(hubRouteForUpdate.hubRouteId());
         validateDepartureHubInRoute(hubRoute, departureHub);
 
-        Hub arrivalHub = Optional.ofNullable(hubRouteForUpdate.arrivalHubId())
-            .map(hubService::validateHub)
-            .orElse(null);
-
-        // TODO : 실제 로직으로 대체하기
-//        BigDecimal distance = arrivalHub != null
-//            ? hubRouteCalculator.getDistance(hubRoute.getDepartureHub(), arrivalHub)
-//            : null;
-//
-//        Integer duration = distance != null
-//            ? hubRouteCalculator.getDuration(distance)
-//            : null;
-        BigDecimal distance = arrivalHub != null
-            ? new BigDecimal("20.5")
-            : null;
-
-        Integer duration = distance != null
-            ? 30
-            : null;
-
-        return hubRoutePersistencePort.updateHubRoute(hubRouteForUpdate, arrivalHub, distance, duration);
+        return hubRoutePersistencePort.updateHubRoute(hubRouteForUpdate);
     }
 
     @Override

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/data/HubRouteEntity.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/data/HubRouteEntity.java
@@ -116,13 +116,10 @@ public class HubRouteEntity extends BaseEntity {
         );
     }
 
-    public void update(HubRouteForUpdate hubRouteForUpdate, HubEntity arrivalHubEntity, BigDecimal distance, Integer duration) {
+    public void update(HubRouteForUpdate hubRouteForUpdate) {
         super.updateFrom(hubRouteForUpdate.userId());
-        Optional.ofNullable(arrivalHubEntity).ifPresent(value -> this.arrivalHub = value);
         Optional.ofNullable(hubRouteForUpdate.timeSlot()).ifPresent(value -> this.timeSlot = value);
         Optional.ofNullable(hubRouteForUpdate.timeSlotWeight()).ifPresent(value -> this.timeSlotWeight = value);
-        Optional.ofNullable(distance).ifPresent(value -> this.distance = value);
-        Optional.ofNullable(duration).ifPresent(value -> this.duration = value);
         Optional.ofNullable(hubRouteForUpdate.status()).ifPresent(value -> this.status = value);
     }
 

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/adapter/HubRoutePersistenceAdapter.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/adapter/HubRoutePersistenceAdapter.java
@@ -69,13 +69,10 @@ public class HubRoutePersistenceAdapter implements HubRoutePersistencePort {
 
     @Transactional
     @Override
-    public HubRoute updateHubRoute(HubRouteForUpdate hubRouteForUpdate, Hub arrivalHub, BigDecimal distance, Integer duration) {
+    public HubRoute updateHubRoute(HubRouteForUpdate hubRouteForUpdate) {
 
         HubRouteEntity hubRouteEntity = hubRouteReadOnlyRepository.findByHubRouteIdAndIsDeletedFalse(hubRouteForUpdate.hubRouteId()).get();
-        HubEntity arrivalHubEntity = arrivalHub != null ?
-        hubReadOnlyRepository.findByHubIdAndIsDeletedFalse(hubRouteForUpdate.arrivalHubId()).get() : null;
-
-        hubRouteEntity.update(hubRouteForUpdate, arrivalHubEntity, distance, duration);
+        hubRouteEntity.update(hubRouteForUpdate);
 
         return hubRouteEntity.toDomain();
     }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteCreateRequest.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteCreateRequest.java
@@ -1,5 +1,6 @@
 package com.sparta.blackyolk.logistic_service.hubroute.framework.web.dto;
 
+import com.sparta.blackyolk.logistic_service.hub.framework.web.validation.ValidCenter;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRouteForCreate;
 import com.sparta.blackyolk.logistic_service.hubroute.application.util.TimeSlotWeightMapper;
 import com.sparta.blackyolk.logistic_service.hubroute.framework.web.validation.ValidTimeSlot;
@@ -8,6 +9,10 @@ import jakarta.validation.constraints.NotBlank;
 public record HubRouteCreateRequest(
     @NotBlank(message = "연결 허브를 입력 해주세요.")
     String targetHubId,
+
+    @NotBlank(message = "연결 허브 센터를 입력해주세요.")
+    @ValidCenter
+    String targetHubCenter,
 
     @ValidTimeSlot
     String timeSlot
@@ -24,6 +29,7 @@ public record HubRouteCreateRequest(
             role,
             hubId,
             hubRouteCreateRequest.targetHubId,
+            hubRouteCreateRequest.targetHubCenter,
             hubRouteCreateRequest.timeSlot,
             TimeSlotWeightMapper.getWeight(hubRouteCreateRequest.timeSlot)
         );

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteUpdateRequest.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteUpdateRequest.java
@@ -6,8 +6,6 @@ import com.sparta.blackyolk.logistic_service.hubroute.data.vo.HubRouteStatus;
 import com.sparta.blackyolk.logistic_service.hubroute.framework.web.validation.ValidTimeSlot;
 
 public record HubRouteUpdateRequest(
-    String targetHubId,
-
     @ValidTimeSlot
     String timeSlot,
 
@@ -29,7 +27,6 @@ public record HubRouteUpdateRequest(
             role,
             hubRouteId,
             departureHubId,
-            hubRouteUpdateRequest.targetHubId,
             hubRouteUpdateRequest.timeSlot,
             weight,
             hubRouteUpdateRequest.status


### PR DESCRIPTION
## 📝 작업 내용

> - Hub 및 HubRoute 등록 시 지정된 Hub 만 등록할 수 있도록 변경합니다. 
>   - 1개의 센터는 1개의 허브만 가질 수 있습니다.  
>   - 주어진 연결 정보를 통해 연결 가능한 허브만 등록하도록 합니다. 

## #️⃣ 연관 이슈
- #34

resolved: #34