### PR TITLE
[#19] 출발 Hub와 도착 Hub 사이의 경로 조회

### DIFF
--- a/logistic-service/.gitignore
+++ b/logistic-service/.gitignore
@@ -38,3 +38,6 @@ out/
 ### VS Code ###
 .vscode/
 .env
+
+hubv1.sql
+hubv2.sql

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/exception/ErrorCode.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/exception/ErrorCode.java
@@ -21,6 +21,8 @@ public enum ErrorCode {
     HUB_ROUTE_NOT_EXIST(404, "HUB_ROUTE_NOT_EXIST", "존재하지 않는 허브 경로입니다."),
     HUB_ROUTE_ALREADY_EXIST(409, "HUB_ROUTE_ALREADY_EXIST", "이미 존재하는 허브 경로입니다."),
 
+    // Path
+    PATH_NOT_EXIST(404, "PATH_NOT_EXIST", "존재하지 경로입니다."),
 
     // example
     INVALID_PARAMETER(400, "INVALID_PARAMETER", "클라이언트에서 요청한 파라미터의 형식이나 내용에 오류가 있는 경우"),

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/exception/ErrorCode.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     FORBIDDEN(403, "USER_FORBIDDEN", "접근 권한이 없습니다."),
 
     // Hub
+    HUB_BAD_REQUEST(400, "HUB_BAD_REQUEST", "잘못된 허브 요청입니다."),
     HUB_NOT_EXIST(404, "HUB_NOT_EXIST", "존재하지 않는 허브입니다."),
     HUB_ALREADY_EXIST(409, "HUB_ALREADY_EXIST", "이미 존재하는 허브입니다."),
 

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/domain/model/Node.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/domain/model/Node.java
@@ -1,0 +1,13 @@
+package com.sparta.blackyolk.logistic_service.hub.application.domain.model;
+
+import com.sparta.blackyolk.logistic_service.hub.application.domain.Hub;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class Node {
+    private final Hub hub; // 현재 탐색 허브
+    private final double g; // 출발 허브에서 현재 허브까지의 실제 비용
+    private final double f; // g + 휴리스틱 비용, (f = g + h)
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/service/HubService.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/service/HubService.java
@@ -22,6 +22,8 @@ public class HubService implements HubUseCase {
     private final String URL = "https://dapi.kakao.com/v2/local/search/address.json?query=";
     private final String ADDRESS = "제주 애월읍";
 
+    // TODO : 캐싱 사용하기
+
     @Override
     public Hub createHub(HubForCreate hubForCreate) {
 

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/service/HubService.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/service/HubService.java
@@ -34,11 +34,10 @@ public class HubService implements HubUseCase {
         BigDecimal axisX = new BigDecimal("126.851675");
         BigDecimal axisY = new BigDecimal("37.54815556");
 
-        // TODO : 허브 이름이나 좌표 혹은 주소 가지고 중복된 허브인지 확인하는 로직 추가 -> domain으로 넘길 수 있을까?
-
         return hubPersistencePort.saveHub(hubForCreate, axisX, axisY);
     }
 
+    // TODO: 불필요한 쿼리가 날아가지 않는가? 확인
     @Override
     public Hub updateHub(HubForUpdate hubForUpdate) {
 

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/service/HubService.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/service/HubService.java
@@ -6,6 +6,7 @@ import com.sparta.blackyolk.logistic_service.hub.application.domain.Hub;
 import com.sparta.blackyolk.logistic_service.hub.application.domain.HubForCreate;
 import com.sparta.blackyolk.logistic_service.hub.application.domain.HubForDelete;
 import com.sparta.blackyolk.logistic_service.hub.application.domain.HubForUpdate;
+import com.sparta.blackyolk.logistic_service.hub.application.domain.model.HubCoordinate;
 import com.sparta.blackyolk.logistic_service.hub.application.port.HubPersistencePort;
 import com.sparta.blackyolk.logistic_service.hub.application.usecase.HubUseCase;
 import java.math.BigDecimal;
@@ -28,13 +29,10 @@ public class HubService implements HubUseCase {
         validateMaster(hubForCreate.role());
         validateHubCenter(hubForCreate.center());
 
-        // TODO: 좌표 조회하는 로직
-        String url = URL + ADDRESS;
+        // TODO: 추후에 좌표 조회하는 로직으로 변경 하기
+        HubCoordinate coordinates = getCoordinatesByCenter(hubForCreate.center());
 
-        BigDecimal axisX = new BigDecimal("126.851675");
-        BigDecimal axisY = new BigDecimal("37.54815556");
-
-        return hubPersistencePort.saveHub(hubForCreate, axisX, axisY);
+        return hubPersistencePort.saveHub(hubForCreate, coordinates.getAxisX(), coordinates.getAxisY());
     }
 
     // TODO: 불필요한 쿼리가 날아가지 않는가? 확인
@@ -92,5 +90,35 @@ public class HubService implements HubUseCase {
         if (hub.isPresent()) {
             throw new CustomException(ErrorCode.HUB_ALREADY_EXIST);
         }
+    }
+
+    // TODO : 추후에 외부 API 를 통한 좌표 조회로 변경 하기
+    /**
+     * 센터에 따른 좌표를 반환하는 메서드
+     *
+     * @param center 센터 이름
+     * @return HubCoordinate 객체 (x, y 좌표)
+     */
+    private HubCoordinate getCoordinatesByCenter(String center) {
+        return switch (center) {
+            case "서울특별시 센터" -> new HubCoordinate(new BigDecimal("126.978388"), new BigDecimal("37.566610"));
+            case "경기 북부 센터" -> new HubCoordinate(new BigDecimal("127.061509"), new BigDecimal("37.895376"));
+            case "경기 남부 센터" -> new HubCoordinate(new BigDecimal("127.123789"), new BigDecimal("37.263573"));
+            case "부산광역시 센터" -> new HubCoordinate(new BigDecimal("129.075642"), new BigDecimal("35.179554"));
+            case "대구광역시 센터" -> new HubCoordinate(new BigDecimal("128.601445"), new BigDecimal("35.871390"));
+            case "인천광역시 센터" -> new HubCoordinate(new BigDecimal("126.705204"), new BigDecimal("37.456256"));
+            case "광주광역시 센터" -> new HubCoordinate(new BigDecimal("126.851338"), new BigDecimal("35.160023"));
+            case "대전광역시 센터" -> new HubCoordinate(new BigDecimal("127.384548"), new BigDecimal("36.350461"));
+            case "울산광역시 센터" -> new HubCoordinate(new BigDecimal("129.311299"), new BigDecimal("35.539777"));
+            case "세종특별자치시 센터" -> new HubCoordinate(new BigDecimal("127.289101"), new BigDecimal("36.480086"));
+            case "강원특별자치도 센터" -> new HubCoordinate(new BigDecimal("127.730594"), new BigDecimal("37.885374"));
+            case "충청북도 센터" -> new HubCoordinate(new BigDecimal("127.491282"), new BigDecimal("36.635748"));
+            case "충청남도 센터" -> new HubCoordinate(new BigDecimal("126.705180"), new BigDecimal("36.518374"));
+            case "전북특별자치도 센터" -> new HubCoordinate(new BigDecimal("127.108759"), new BigDecimal("35.821058"));
+            case "전라남도 센터" -> new HubCoordinate(new BigDecimal("126.462919"), new BigDecimal("34.816111"));
+            case "경상북도 센터" -> new HubCoordinate(new BigDecimal("128.602750"), new BigDecimal("36.574493"));
+            case "경상남도 센터" -> new HubCoordinate(new BigDecimal("128.259623"), new BigDecimal("35.460773"));
+            default -> throw new CustomException(ErrorCode.HUB_BAD_REQUEST);
+        };
     }
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/data/vo/HubAddressEmbeddable.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/data/vo/HubAddressEmbeddable.java
@@ -19,7 +19,7 @@ public class HubAddressEmbeddable {
     @Column(name = "sido", nullable = false)
     private String sido;
 
-    @Column(name = "sigungu", nullable = false)
+    @Column(name = "sigungu")
     private String sigungu;
 
     @Column(name = "eupmyun")

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRoute.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRoute.java
@@ -14,21 +14,15 @@ public class HubRoute {
     private Hub departureHub;
     private Hub arrivalHub;
     private HubRouteStatus status;
-    private String timeSlot;
     private Integer duration;
     private BigDecimal distance;
-    private double timeSlotWeight;
 
     public HubRoute(
         Hub departureHub,
-        Hub arrivalHub,
-        String timeSlot,
-        double timeSlotWeight
+        Hub arrivalHub
     ) {
         this.departureHub = departureHub;
         this.arrivalHub = arrivalHub;
-        this.timeSlot = timeSlot;
-        this.timeSlotWeight = timeSlotWeight;
         this.distance = calculateDistance();
         this.duration = calculateDuration();
     }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRouteForCreate.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRouteForCreate.java
@@ -5,9 +5,7 @@ public record HubRouteForCreate(
     String role,
     String departureHubId,
     String arrivalHubId,
-    String targetHubCenter,
-    String timeSlot,
-    double timeSlotWeight
+    String targetHubCenter
 ) {
 
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRouteForUpdate.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRouteForUpdate.java
@@ -6,9 +6,7 @@ public record HubRouteForUpdate(
     Long userId,
     String role,
     String hubRouteId,
-    String departureHubId,
-    String timeSlot,
-    Double timeSlotWeight, // timeslot이 없으면 null 처리를 할 수 있도록 Double로 설정,
+    String departureHubId, // timeslot이 없으면 null 처리를 할 수 있도록 Double로 설정,
     HubRouteStatus status
 ) {
 

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/port/HubRoutePersistencePort.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/port/HubRoutePersistencePort.java
@@ -3,6 +3,7 @@ package com.sparta.blackyolk.logistic_service.hubroute.application.port;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRoute;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRouteForDelete;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRouteForUpdate;
+import java.util.List;
 import java.util.Optional;
 
 public interface HubRoutePersistencePort {
@@ -10,4 +11,7 @@ public interface HubRoutePersistencePort {
     Optional<HubRoute> findByHubRouteId(String hubRouteId);
     HubRoute updateHubRoute(HubRouteForUpdate hubRouteForUpdate);
     HubRoute deleteHubRoute(HubRouteForDelete hubRouteForDelete);
+    Optional<HubRoute> findHubRouteByDepartureHubIdAndArrivalHubId(String departureHubId, String arrivalHubId);
+    List<HubRoute> findAllHubRoutes();
+    List<HubRoute> findAllByHubId(String hubId);
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/service/HubRoutePathService.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/service/HubRoutePathService.java
@@ -1,0 +1,228 @@
+package com.sparta.blackyolk.logistic_service.hubroute.application.service;
+
+import com.sparta.blackyolk.logistic_service.common.exception.CustomException;
+import com.sparta.blackyolk.logistic_service.common.exception.ErrorCode;
+import com.sparta.blackyolk.logistic_service.hub.application.domain.Hub;
+import com.sparta.blackyolk.logistic_service.hub.application.domain.model.Node;
+import com.sparta.blackyolk.logistic_service.hub.application.service.HubService;
+import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRoute;
+import com.sparta.blackyolk.logistic_service.hubroute.application.port.HubRoutePersistencePort;
+import com.sparta.blackyolk.logistic_service.hubroute.application.usecase.HubRoutePathUseCase;
+import com.sparta.blackyolk.logistic_service.hubroute.application.util.TimeSlotWeightMapper;
+import com.sparta.blackyolk.logistic_service.hubroute.framework.web.dto.HubRoutePathResponse;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import lombok.RequiredArgsConstructor;
+import java.util.Comparator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class HubRoutePathService implements HubRoutePathUseCase {
+
+    private final HubRoutePersistencePort hubRoutePersistencePort;
+    private final HubService hubService;
+    private final TimeSlotWeightMapper timeSlotWeightMapper;
+
+    @Override
+    public HubRoutePathResponse getShortestPath(String departure, String arrival) {
+        LocalDateTime now = LocalDateTime.now();
+        String currentTimeSlot = getCurrentTimeSlot(now);
+
+        log.info("[최단 경로 탐색] 현재 시간대 : {}", currentTimeSlot);
+
+        Hub departureHub = hubService.validateHub(departure);
+        Hub arrivalHub = hubService.validateHub(arrival);
+        log.info("[최단 경로 탐색] 출발 허브: {}, 도착 허브: {}", departureHub.getHubName(), arrivalHub.getHubName());
+
+        log.info("[최단 경로 탐색] {} 에서 {} 로의 최단 경로, 시간대: {}", departureHub.getHubName(), arrivalHub.getHubName(), currentTimeSlot);
+
+        List<HubRoute> shortestPath = findShortestPath(currentTimeSlot, departureHub, arrivalHub);
+
+        log.info("[최단 경로 탐색] 최단 경로 : {}", shortestPath);
+
+        return HubRoutePathResponse.toDTO(
+            departureHub.getHubName(),
+            arrivalHub.getHubName(),
+            shortestPath
+        );
+    }
+
+    private String getCurrentTimeSlot(LocalDateTime now) {
+        String time = now.format(DateTimeFormatter.ofPattern("HH:mm"));
+        String timeSlot = timeSlotWeightMapper.getTimeSlots().keySet().stream()
+            .filter(slot -> isTimeInSlot(slot, time))
+            .findFirst()
+            .orElse("22:00-05:00");
+
+        log.info("[최단 경로 탐색] 시간대 : {}, 현재 시각: {}", timeSlot, time);
+        return timeSlot;
+    }
+
+    private boolean isTimeInSlot(String slot, String time) {
+        String[] timeRange = slot.split("-");
+        String startTime = timeRange[0];
+        String endTime = timeRange[1];
+        return isCrossingMidnight(startTime, endTime)
+            ? time.compareTo(startTime) >= 0 || time.compareTo(endTime) < 0
+            : time.compareTo(startTime) >= 0 && time.compareTo(endTime) < 0;
+    }
+
+    private boolean isCrossingMidnight(String startTime, String endTime) {
+        return endTime.compareTo(startTime) < 0;
+    }
+
+    private List<HubRoute> findShortestPath(String currentTimeSlot, Hub departureHub, Hub arrivalHub) {
+        PriorityQueue<Node> candidateNodes = initializeCandidateNodes(departureHub, arrivalHub);
+        Map<Hub, Double> costFromStart = initializeCostFromStart(departureHub);
+        Map<Hub, Node> previousNodes = new HashMap<>();
+
+        log.info("[최단 경로 탐색] candidateNodes 크기: {}", candidateNodes.size());
+
+        while (!candidateNodes.isEmpty()) {
+            Node currentNode = candidateNodes.poll();
+
+            if (currentNode == null) {
+                log.error("[최단 경로 탐색] currentNode가 null입니다.");
+                throw new CustomException(ErrorCode.PATH_NOT_EXIST);
+            }
+
+            log.info("[최단 경로 탐색] 현재 허브: {}, 현재 비용: {}", currentNode.getHub().getHubName(), currentNode.getG());
+
+            if (currentNode.getHub().getHubId().equals(arrivalHub.getHubId())) {
+                log.info("[최단 경로 탐색] 최종 허브에 도달: {}", arrivalHub.getHubName());
+                return reconstructPath(previousNodes, currentNode);
+            }
+
+            log.info("[최단 경로 탐색] processNeighbors 호출 준비: currentNode={}, arrivalHub={}, candidateNodes size={}",
+                currentNode.getHub().getHubName(), arrivalHub.getHubName(), candidateNodes.size());
+
+            processNeighbors(
+                currentNode,
+                arrivalHub,
+                candidateNodes,
+                costFromStart,
+                previousNodes,
+                currentTimeSlot
+            );
+        }
+
+        log.info("[최단 경로 탐색] 허브 경로 없음 {} -> {}", departureHub.getHubName(), arrivalHub.getHubName());
+        throw new CustomException(ErrorCode.PATH_NOT_EXIST);
+    }
+
+    private PriorityQueue<Node> initializeCandidateNodes(Hub departureHub, Hub arrivalHub) {
+        PriorityQueue<Node> candidateNodes = new PriorityQueue<>(Comparator.comparingDouble(Node::getF));
+        candidateNodes.add(new Node(departureHub, 0, heuristic(departureHub, arrivalHub)));
+        log.info("[최단 경로 탐색] candidate nodes 초기화: {}", departureHub.getHubName());
+        return candidateNodes;
+    }
+
+    private Map<Hub, Double> initializeCostFromStart(Hub departureHub) {
+        Map<Hub, Double> costFromStart = new HashMap<>();
+        costFromStart.put(departureHub, 0.0);
+        log.info("[최단 경로 탐색] cost from start 초기화: {}, cost: 0", departureHub.getHubName());
+        return costFromStart;
+    }
+
+    private void processNeighbors(
+        Node currentNode,
+        Hub arrivalHub,
+        PriorityQueue<Node> candidateNodes,
+        Map<Hub, Double> costFromStart,
+        Map<Hub, Node> previousNodes,
+        String currentTimeSlot
+    ) {
+        log.info("[최단 경로 탐색] 현재 경로: {}, Hub ID: {}", currentNode.getHub().getHubName(), currentNode.getHub().getHubId());
+
+        List<HubRoute> neighbors = hubRoutePersistencePort.findAllByHubId(currentNode.getHub().getHubId());
+
+        log.info("[최단 경로 탐색] 허브 {}의 이웃 허브 개수: {}", currentNode.getHub().getHubName(), neighbors.size());
+        if (neighbors.isEmpty()) {
+            log.warn("[최단 경로 탐색] 허브 {}의 이웃 노드가 없습니다.", currentNode.getHub().getHubName());
+            return;
+        }
+
+        for (HubRoute route : neighbors) {
+            double timeSlotWeight = timeSlotWeightMapper.getWeight(currentTimeSlot);
+            log.info("[최단 경로 탐색] 시간대 {}의 가중치: {}", currentTimeSlot, timeSlotWeight);
+
+            double expectedCost = calculateExpectedCost(currentNode, route, timeSlotWeight, costFromStart);
+
+            if (expectedCost < costFromStart.getOrDefault(route.getArrivalHub(), Double.MAX_VALUE)) {
+                log.info("[최단 경로 탐색] 비용 업데이트: {}, 예상 비용: {}", route.getArrivalHub().getHubName(), expectedCost);
+                updateCosts(route, expectedCost, arrivalHub, costFromStart, previousNodes, candidateNodes, currentNode);
+            }
+        }
+    }
+
+    private double calculateExpectedCost(Node currentNode, HubRoute route, double timeSlotWeight, Map<Hub, Double> costFromStart) {
+        double cost = costFromStart.getOrDefault(currentNode.getHub(), Double.MAX_VALUE)
+            + route.getDistance().doubleValue() * timeSlotWeight;
+        log.info("[최단 경로 탐색] 예상 경로 비용 {} -> {}: {}",
+                  currentNode.getHub().getHubName(), route.getArrivalHub().getHubName(), cost);
+        return cost;
+    }
+
+    private void updateCosts(
+        HubRoute route,
+        double expectedCost,
+        Hub arrivalHub,
+        Map<Hub, Double> costFromStart,
+        Map<Hub, Node> previousNodes,
+        PriorityQueue<Node> candidateNodes,
+        Node currentNode
+    ) {
+        costFromStart.put(route.getArrivalHub(), expectedCost);
+        previousNodes.put(route.getArrivalHub(), currentNode);
+        double fScore = expectedCost + heuristic(route.getArrivalHub(), arrivalHub);
+        candidateNodes.add(new Node(route.getArrivalHub(), expectedCost, fScore));
+
+        log.info("[최단 경로 탐색] candidate nodes 에: {} 추가, fScore: {}",
+                  route.getArrivalHub().getHubName(), fScore);
+    }
+
+    private List<HubRoute> reconstructPath(Map<Hub, Node> previousNodes, Node currentNode) {
+        List<HubRoute> path = new ArrayList<>();
+        Node node = currentNode;
+
+        while (node != null) {
+            Node previousNode = previousNodes.get(node.getHub());
+            if (previousNode != null) {
+                HubRoute route = hubRoutePersistencePort
+                    .findHubRouteByDepartureHubIdAndArrivalHubId(
+                        previousNode.getHub().getHubId(),
+                        node.getHub().getHubId()
+                    ).orElseThrow(() -> new CustomException(ErrorCode.HUB_ROUTE_NOT_EXIST));
+
+                log.info("[최단 경로 탐색] route 추가 {} -> {}",
+                          previousNode.getHub().getHubName(), node.getHub().getHubName());
+                path.add(route);
+            }
+            node = previousNode;
+        }
+
+        Collections.reverse(path);
+        log.info("[최단 경로 탐색] 경로 재구성: {}", path);
+        return path;
+    }
+
+    private double heuristic(Hub current, Hub goal) {
+        BigDecimal dx = current.getHubCoordinate().getAxisX().subtract(goal.getHubCoordinate().getAxisX());
+        BigDecimal dy = current.getHubCoordinate().getAxisY().subtract(goal.getHubCoordinate().getAxisY());
+
+        double distance = Math.sqrt(dx.pow(2).add(dy.pow(2)).doubleValue());
+        log.info("[최단 경로 탐색] heuristic distance 계산 {} -> {}: {}", current.getHubName(), goal.getHubName(), distance);
+        return distance;
+    }
+}
+

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/service/HubRouteService.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/service/HubRouteService.java
@@ -13,10 +13,8 @@ import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRout
 import com.sparta.blackyolk.logistic_service.hubroute.application.port.HubRouteCalculator;
 import com.sparta.blackyolk.logistic_service.hubroute.application.port.HubRoutePersistencePort;
 import com.sparta.blackyolk.logistic_service.hubroute.application.usecase.HubRouteUseCase;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,6 +29,7 @@ public class HubRouteService implements HubRouteUseCase {
     private final HubRouteCalculator hubRouteCalculator;
 
     // TODO : 쿼리 몇번 날아가는 지 확인, 불필요한 쿼리가 날아가지 않은가?
+    // TODO : 캐싱 사용하기
 
     @Override
     public HubRoute getHubRoute(HubRouteForRead hubRouteForRead) {
@@ -70,9 +69,7 @@ public class HubRouteService implements HubRouteUseCase {
 
         HubRoute hubRoute = new HubRoute(
             departureHub,
-            arrivalHub,
-            hubRouteForCreate.timeSlot(),
-            hubRouteForCreate.timeSlotWeight()
+            arrivalHub
         );
 
         return hubRoutePersistencePort.createHubRoute(hubRouteForCreate.userId(), hubRoute);

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/usecase/HubRoutePathUseCase.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/usecase/HubRoutePathUseCase.java
@@ -1,0 +1,7 @@
+package com.sparta.blackyolk.logistic_service.hubroute.application.usecase;
+
+import com.sparta.blackyolk.logistic_service.hubroute.framework.web.dto.HubRoutePathResponse;
+
+public interface HubRoutePathUseCase {
+    HubRoutePathResponse getShortestPath(String departure, String arrival);
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/util/TimeSlotWeightMapper.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/util/TimeSlotWeightMapper.java
@@ -1,19 +1,29 @@
 package com.sparta.blackyolk.logistic_service.hubroute.application.util;
 
 import java.util.Map;
+import org.springframework.stereotype.Component;
 
+@Component
 public class TimeSlotWeightMapper {
 
-    public static final Map<String, Double> TIME_SLOT_WEIGHTS = Map.of(
-        "22:00-05:00", 1.0,
-        "05:00-07:00", 1.2,
-        "07:00-09:00", 2.0,
-        "09:00-17:00", 1.5,
-        "17:00-20:00", 2.0,
-        "20:00-22:00", 1.2
-    );
+    private static final Map<String, Double> TIME_SLOT_WEIGHTS;
 
-    public static double getWeight(String timeSlot) {
-        return TIME_SLOT_WEIGHTS.get(timeSlot);
+    static {
+        TIME_SLOT_WEIGHTS = Map.of(
+            "22:00-05:00", 1.0,
+            "05:00-07:00", 1.2,
+            "07:00-09:00", 2.0,
+            "09:00-17:00", 1.5,
+            "17:00-20:00", 2.0,
+            "20:00-22:00", 1.2
+        );
+    }
+
+    public double getWeight(String timeSlot) {
+        return TIME_SLOT_WEIGHTS.getOrDefault(timeSlot, 1.0);
+    }
+
+    public Map<String, Double> getTimeSlots() {
+        return TIME_SLOT_WEIGHTS;
     }
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/util/TimeSlotWeightMapper.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/util/TimeSlotWeightMapper.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 public class TimeSlotWeightMapper {
 
-    private static final Map<String, Double> TIME_SLOT_WEIGHTS = Map.of(
+    public static final Map<String, Double> TIME_SLOT_WEIGHTS = Map.of(
         "22:00-05:00", 1.0,
         "05:00-07:00", 1.2,
         "07:00-09:00", 2.0,

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/data/HubRouteEntity.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/data/HubRouteEntity.java
@@ -44,7 +44,7 @@ public class HubRouteEntity extends BaseEntity {
     private HubEntity arrivalHub;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "hub_status", nullable = false, columnDefinition = "varchar(255)")
+    @Column(name = "hub_route_status", nullable = false, columnDefinition = "varchar(255)")
     private HubRouteStatus status = HubRouteStatus.ACTIVE;
 
     @Column(name = "duration", nullable = false)
@@ -52,12 +52,6 @@ public class HubRouteEntity extends BaseEntity {
 
     @Column(name = "distance", precision = 10, scale = 2, nullable = false)
     private BigDecimal distance; // km
-
-    @Column(name = "time_slot", nullable = false, columnDefinition = "varchar(255)")
-    private String timeSlot; // ex. 09:00-12:00
-
-    @Column(name = "time_slot_weight", nullable = false)
-    private double timeSlotWeight; // 시간대 별 가중치
 
     @PrePersist
     private void prePersistence() {
@@ -71,9 +65,7 @@ public class HubRouteEntity extends BaseEntity {
         HubEntity departureHub,
         HubEntity arrivalHub,
         Integer duration,
-        BigDecimal distance,
-        String timeSlot,
-        double timeSlotWeight
+        BigDecimal distance
     ) {
         super(userId, userId);
         this.hubRouteId = null;
@@ -81,8 +73,6 @@ public class HubRouteEntity extends BaseEntity {
         this.arrivalHub = arrivalHub;
         this.duration = duration;
         this.distance = distance;
-        this.timeSlot = timeSlot;
-        this.timeSlotWeight = timeSlotWeight;
     }
 
     public static HubRouteEntity toEntity(
@@ -96,9 +86,7 @@ public class HubRouteEntity extends BaseEntity {
             departureHubEntity,
             arrivalHubEntity,
             hubRoute.getDuration(),
-            hubRoute.getDistance(),
-            hubRoute.getTimeSlot(),
-            hubRoute.getTimeSlotWeight()
+            hubRoute.getDistance()
         );
     }
 
@@ -109,17 +97,13 @@ public class HubRouteEntity extends BaseEntity {
             this.departureHub.toDomain(),
             this.arrivalHub.toDomain(),
             this.status,
-            this.timeSlot,
             this.duration,
-            this.distance,
-            this.timeSlotWeight
+            this.distance
         );
     }
 
     public void update(HubRouteForUpdate hubRouteForUpdate) {
         super.updateFrom(hubRouteForUpdate.userId());
-        Optional.ofNullable(hubRouteForUpdate.timeSlot()).ifPresent(value -> this.timeSlot = value);
-        Optional.ofNullable(hubRouteForUpdate.timeSlotWeight()).ifPresent(value -> this.timeSlotWeight = value);
         Optional.ofNullable(hubRouteForUpdate.status()).ifPresent(value -> this.status = value);
     }
 

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/adapter/HubRoutePersistenceAdapter.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/adapter/HubRoutePersistenceAdapter.java
@@ -11,6 +11,7 @@ import com.sparta.blackyolk.logistic_service.hubroute.framework.repository.HubRo
 import com.sparta.blackyolk.logistic_service.hubroute.framework.repository.HubRouteRepository;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -33,12 +34,33 @@ public class HubRoutePersistenceAdapter implements HubRoutePersistencePort {
     }
 
     @Transactional(readOnly = true)
-    public Page<HubRouteEntity> findAllHubRoutesByHubIdWithKeyword(String hubId, String keyword, Pageable pageable) {
+    public Page<HubRoute> findAllHubRoutesByHubIdWithKeyword(String hubId, String keyword, Pageable pageable) {
         return hubRouteReadOnlyRepository.findAllHubRoutesByHubIdAndIsDeletedFalseWithKeyword(
             hubId,
             keyword,
             pageable
-        );
+        ).map(HubRouteEntity::toDomain);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<HubRoute> findHubRouteByDepartureHubIdAndArrivalHubId(String departureHubId, String arrivalHubId) {
+        return hubRouteReadOnlyRepository.findByDepartureHubIdAndArrivalHubId(departureHubId, arrivalHubId)
+            .map(HubRouteEntity::toDomain)
+            .or(Optional::empty);
+    }
+
+    @Override
+    public List<HubRoute> findAllHubRoutes() {
+        return hubRouteReadOnlyRepository.findAllHubRoutesAndIsDeletedFalseAndActive().stream()
+            .map(HubRouteEntity::toDomain)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<HubRoute> findAllByHubId(String hubId) {
+        return hubRouteReadOnlyRepository.findAllByHubIdAndIsDeletedFalseAndActive(hubId).stream()
+            .map(HubRouteEntity::toDomain)
+            .collect(Collectors.toList());
     }
 
     @Transactional

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/adapter/HubRoutePersistenceAdapter.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/adapter/HubRoutePersistenceAdapter.java
@@ -1,6 +1,5 @@
 package com.sparta.blackyolk.logistic_service.hubroute.framework.adapter;
 
-import com.sparta.blackyolk.logistic_service.hub.application.domain.Hub;
 import com.sparta.blackyolk.logistic_service.hub.data.HubEntity;
 import com.sparta.blackyolk.logistic_service.hub.framework.repository.HubReadOnlyRepository;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRoute;
@@ -10,7 +9,6 @@ import com.sparta.blackyolk.logistic_service.hubroute.application.port.HubRouteP
 import com.sparta.blackyolk.logistic_service.hubroute.data.HubRouteEntity;
 import com.sparta.blackyolk.logistic_service.hubroute.framework.repository.HubRouteReadOnlyRepository;
 import com.sparta.blackyolk.logistic_service.hubroute.framework.repository.HubRouteRepository;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/repository/HubRouteReadOnlyRepository.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/repository/HubRouteReadOnlyRepository.java
@@ -10,4 +10,7 @@ public interface HubRouteReadOnlyRepository {
     Optional<HubRouteEntity> findByHubRouteIdAndIsDeletedFalse(String hubRouteId);
     Page<HubRouteEntity> findAllHubRoutesByHubIdAndIsDeletedFalseWithKeyword(String hubId, String keyword, Pageable pageable);
     List<HubRouteEntity> findAllHubRoutesByHubIdAndIsDeletedFalse(String hubId);
+    Optional<HubRouteEntity> findByDepartureHubIdAndArrivalHubId(String departureHubId, String arrivalHubId);
+    List<HubRouteEntity> findAllHubRoutesAndIsDeletedFalseAndActive();
+    List<HubRouteEntity> findAllByHubIdAndIsDeletedFalseAndActive(String hubId);
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/controller/HubRoutePathQueryController.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/controller/HubRoutePathQueryController.java
@@ -1,0 +1,31 @@
+package com.sparta.blackyolk.logistic_service.hubroute.framework.web.controller;
+
+import com.sparta.blackyolk.logistic_service.hubroute.application.usecase.HubRoutePathUseCase;
+import com.sparta.blackyolk.logistic_service.hubroute.framework.web.dto.HubRoutePathResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/hub-routes")
+public class HubRoutePathQueryController {
+
+    private final HubRoutePathUseCase hubRoutePathUseCase;
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/shortest-path")
+    public HubRoutePathResponse getShortestPath(
+        @RequestParam(value = "departure") String departure,
+        @RequestParam(value = "arrival") String arrival
+
+    ) {
+        return hubRoutePathUseCase.getShortestPath(departure, arrival);
+    }
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/controller/HubRouteQueryController.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/controller/HubRouteQueryController.java
@@ -56,7 +56,7 @@ public class HubRouteQueryController {
         // TODO : user token, user role 받아야 하나?
         log.info("[HubRoute search 조회 pageable] : {}", pageable);
 
-        Page<HubRouteEntity> hubRoutePage = hubRoutePersistenceAdapter.findAllHubRoutesByHubIdWithKeyword(
+        Page<HubRoute> hubRoutePage = hubRoutePersistenceAdapter.findAllHubRoutesByHubIdWithKeyword(
             hubId,
             keyword,
             pageable

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteCreateRequest.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteCreateRequest.java
@@ -2,8 +2,6 @@ package com.sparta.blackyolk.logistic_service.hubroute.framework.web.dto;
 
 import com.sparta.blackyolk.logistic_service.hub.framework.web.validation.ValidCenter;
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRouteForCreate;
-import com.sparta.blackyolk.logistic_service.hubroute.application.util.TimeSlotWeightMapper;
-import com.sparta.blackyolk.logistic_service.hubroute.framework.web.validation.ValidTimeSlot;
 import jakarta.validation.constraints.NotBlank;
 
 public record HubRouteCreateRequest(
@@ -12,10 +10,7 @@ public record HubRouteCreateRequest(
 
     @NotBlank(message = "연결 허브 센터를 입력해주세요.")
     @ValidCenter
-    String targetHubCenter,
-
-    @ValidTimeSlot
-    String timeSlot
+    String targetHubCenter
 ) {
 
     public static HubRouteForCreate toDomain(
@@ -29,9 +24,7 @@ public record HubRouteCreateRequest(
             role,
             hubId,
             hubRouteCreateRequest.targetHubId,
-            hubRouteCreateRequest.targetHubCenter,
-            hubRouteCreateRequest.timeSlot,
-            TimeSlotWeightMapper.getWeight(hubRouteCreateRequest.timeSlot)
+            hubRouteCreateRequest.targetHubCenter
         );
     }
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteCreateResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteCreateResponse.java
@@ -10,8 +10,7 @@ public record HubRouteCreateResponse(
     String arrivalHubName,
     HubRouteStatus hubRouteStatus,
     BigDecimal distance,
-    Integer duration,
-    String timeSlot
+    Integer duration
 ) {
 
     public static HubRouteCreateResponse toDTO(
@@ -23,8 +22,7 @@ public record HubRouteCreateResponse(
             hubRoute.getArrivalHub().getHubName(),
             hubRoute.getStatus(),
             hubRoute.getDistance(),
-            hubRoute.getDuration(),
-            hubRoute.getTimeSlot()
+            hubRoute.getDuration()
         );
     }
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteGetResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteGetResponse.java
@@ -10,8 +10,7 @@ public record HubRouteGetResponse(
     String arrivalHubName,
     HubRouteStatus hubRouteStatus,
     BigDecimal distance,
-    Integer duration,
-    String timeSlot
+    Integer duration
 ) {
 
     public static HubRouteGetResponse toDTO(
@@ -23,8 +22,7 @@ public record HubRouteGetResponse(
             hubRoute.getArrivalHub().getHubName(),
             hubRoute.getStatus(),
             hubRoute.getDistance(),
-            hubRoute.getDuration(),
-            hubRoute.getTimeSlot()
+            hubRoute.getDuration()
         );
     }
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRoutePageResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRoutePageResponse.java
@@ -31,8 +31,7 @@ public record HubRoutePageResponse(
         String arrivalHubName,
         HubRouteStatus hubRouteStatus,
         BigDecimal distance,
-        Integer duration,
-        String timeSlot
+        Integer duration
     ) {
         public static List<HubRouteResponse> toDTO(List<HubRouteEntity> hubRouteEntityList) {
             return hubRouteEntityList.stream()
@@ -47,8 +46,7 @@ public record HubRoutePageResponse(
                 hubRouteEntity.getArrivalHub().getHubName(),
                 hubRouteEntity.getStatus(),
                 hubRouteEntity.getDistance(),
-                hubRouteEntity.getDuration(),
-                hubRouteEntity.getTimeSlot()
+                hubRouteEntity.getDuration()
             );
         }
     }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRoutePageResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRoutePageResponse.java
@@ -1,6 +1,6 @@
 package com.sparta.blackyolk.logistic_service.hubroute.framework.web.dto;
 
-import com.sparta.blackyolk.logistic_service.hubroute.data.HubRouteEntity;
+import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRoute;
 import com.sparta.blackyolk.logistic_service.hubroute.data.vo.HubRouteStatus;
 import java.math.BigDecimal;
 import java.util.List;
@@ -12,7 +12,7 @@ public record HubRoutePageResponse(
 ) {
 
     public HubRoutePageResponse(
-        Page<HubRouteEntity> hubRoutePage
+        Page<HubRoute> hubRoutePage
     ) {
         this(
             new PageInfo(
@@ -33,20 +33,20 @@ public record HubRoutePageResponse(
         BigDecimal distance,
         Integer duration
     ) {
-        public static List<HubRouteResponse> toDTO(List<HubRouteEntity> hubRouteEntityList) {
+        public static List<HubRouteResponse> toDTO(List<HubRoute> hubRouteEntityList) {
             return hubRouteEntityList.stream()
                 .map(HubRouteResponse::toDTO)
                 .toList();
         }
 
-        public static HubRouteResponse toDTO(HubRouteEntity hubRouteEntity) {
+        public static HubRouteResponse toDTO(HubRoute hubRoute) {
             return new HubRouteResponse(
-                hubRouteEntity.getHubRouteId(),
-                hubRouteEntity.getDepartureHub().getHubName(),
-                hubRouteEntity.getArrivalHub().getHubName(),
-                hubRouteEntity.getStatus(),
-                hubRouteEntity.getDistance(),
-                hubRouteEntity.getDuration()
+                hubRoute.getHubRouteId(),
+                hubRoute.getDepartureHub().getHubName(),
+                hubRoute.getArrivalHub().getHubName(),
+                hubRoute.getStatus(),
+                hubRoute.getDistance(),
+                hubRoute.getDuration()
             );
         }
     }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRoutePathResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRoutePathResponse.java
@@ -8,14 +8,14 @@ public record HubRoutePathResponse(
     String departureHub,
     String arrivalHub,
     BigDecimal totalDistance,
-    int totalDuration,
+    double totalDuration,
     List<PathResponse> paths
 ) {
     public record PathResponse(
         String from,
         String to,
         BigDecimal distance,
-        int duration
+        double duration
     ) {
 
     }
@@ -23,14 +23,15 @@ public record HubRoutePathResponse(
     public static HubRoutePathResponse toDTO(
         String departureHub,
         String arrivalHub,
-        List<HubRoute> hubRouteList
+        List<HubRoute> hubRouteList,
+        double timeSlotWeight
     ) {
         List<PathResponse> paths = hubRouteList.stream()
             .map(route -> new PathResponse(
                 route.getDepartureHub().getHubName(),
                 route.getArrivalHub().getHubName(),
                 route.getDistance(),
-                route.getDuration()
+                route.getDuration()*timeSlotWeight
             ))
             .toList();
 
@@ -38,8 +39,8 @@ public record HubRoutePathResponse(
             .map(HubRoute::getDistance)
             .reduce(BigDecimal.ZERO, BigDecimal::add);
 
-        int totalDuration = hubRouteList.stream()
-            .mapToInt(HubRoute::getDuration)
+        double totalDuration = hubRouteList.stream()
+            .mapToDouble(route -> route.getDuration() * timeSlotWeight)
             .sum();
 
         return new HubRoutePathResponse(

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRoutePathResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRoutePathResponse.java
@@ -1,0 +1,53 @@
+package com.sparta.blackyolk.logistic_service.hubroute.framework.web.dto;
+
+import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRoute;
+import java.math.BigDecimal;
+import java.util.List;
+
+public record HubRoutePathResponse(
+    String departureHub,
+    String arrivalHub,
+    BigDecimal totalDistance,
+    int totalDuration,
+    List<PathResponse> paths
+) {
+    public record PathResponse(
+        String from,
+        String to,
+        BigDecimal distance,
+        int duration
+    ) {
+
+    }
+
+    public static HubRoutePathResponse toDTO(
+        String departureHub,
+        String arrivalHub,
+        List<HubRoute> hubRouteList
+    ) {
+        List<PathResponse> paths = hubRouteList.stream()
+            .map(route -> new PathResponse(
+                route.getDepartureHub().getHubName(),
+                route.getArrivalHub().getHubName(),
+                route.getDistance(),
+                route.getDuration()
+            ))
+            .toList();
+
+        BigDecimal totalDistance = hubRouteList.stream()
+            .map(HubRoute::getDistance)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        int totalDuration = hubRouteList.stream()
+            .mapToInt(HubRoute::getDuration)
+            .sum();
+
+        return new HubRoutePathResponse(
+            departureHub,
+            arrivalHub,
+            totalDistance,
+            totalDuration,
+            paths
+        );
+    }
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteUpdateRequest.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteUpdateRequest.java
@@ -1,13 +1,9 @@
 package com.sparta.blackyolk.logistic_service.hubroute.framework.web.dto;
 
 import com.sparta.blackyolk.logistic_service.hubroute.application.domain.HubRouteForUpdate;
-import com.sparta.blackyolk.logistic_service.hubroute.application.util.TimeSlotWeightMapper;
 import com.sparta.blackyolk.logistic_service.hubroute.data.vo.HubRouteStatus;
-import com.sparta.blackyolk.logistic_service.hubroute.framework.web.validation.ValidTimeSlot;
 
 public record HubRouteUpdateRequest(
-    @ValidTimeSlot
-    String timeSlot,
 
     HubRouteStatus status
 ) {
@@ -19,16 +15,11 @@ public record HubRouteUpdateRequest(
         String hubRouteId,
         HubRouteUpdateRequest hubRouteUpdateRequest
     ) {
-        Double weight = hubRouteUpdateRequest.timeSlot != null ?
-            TimeSlotWeightMapper.getWeight(hubRouteUpdateRequest.timeSlot) : null;
-
         return new HubRouteForUpdate(
             userId,
             role,
             hubRouteId,
             departureHubId,
-            hubRouteUpdateRequest.timeSlot,
-            weight,
             hubRouteUpdateRequest.status
         );
     }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteUpdateResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteUpdateResponse.java
@@ -10,8 +10,7 @@ public record HubRouteUpdateResponse(
     String arrivalHubName,
     HubRouteStatus hubRouteStatus,
     BigDecimal distance,
-    Integer duration,
-    String timeSlot
+    Integer duration
 ) {
     public static HubRouteUpdateResponse toDTO(
         HubRoute hubRoute
@@ -22,8 +21,7 @@ public record HubRouteUpdateResponse(
             hubRoute.getArrivalHub().getHubName(),
             hubRoute.getStatus(),
             hubRoute.getDistance(),
-            hubRoute.getDuration(),
-            hubRoute.getTimeSlot()
+            hubRoute.getDuration()
         );
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

> - A* 알고리즘을 사용하여 출발 Hub에서 도착 Hub까지의 경로를 조회합니다. 
>   - 경로 조회를 요청한 시간대를 반영하여 시간대 별 가중치를 적용하였습니다. 
>   - 경로는 연결된 허브로만 이동이 가능합니다. 

### 연결 허브 정보 
```
- 허브는 아래와 같이 연결되어 있습니다.
    - 경기남부: 경기북부, 서울, 인천, 강원도, 경상북도, 대전, 대구
    - 대전: 충청남도, 충청북도, 세종, 전라북도, 광주, 전라남도, 경기남부, 대구
    - 대구: 경상북도, 경상남도, 부산, 울산, 경상북도, 경기남부, 대전
    - 경상북도: 경기남부, 대구
```

### 시간대 별 가중치 정보 

- 가중치가 높을 수록 소요 시간이 오래 걸립니다.

시간대 | 가중치
-- | --
22:00 ~ 05:00 | 1.0
05:00 ~ 07:00 | 1.2
07:00 ~ 09:00 | 2.0
09:00 ~ 17:00 | 1.5
17:00 ~ 20:00 | 2.0
20:00 ~ 22:00 | 1.2


## #️⃣ 연관 이슈
- #19

resolved: #19
