### PR TITLE
[#20] Hub 및 HubRoute에 userId 및 role header 추가 및 gateway filter 수정

### DIFF
--- a/gateway/src/main/java/com/sparta/blackyolk/gateway/LocalJwtAuthenticationFilter.java
+++ b/gateway/src/main/java/com/sparta/blackyolk/gateway/LocalJwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
@@ -51,14 +52,25 @@ public class LocalJwtAuthenticationFilter implements GlobalFilter {
         }
 
         // JWT 토큰 검증
-        if (!validateToken(token, exchange)) {
-            log.warn("Token validation failed for token: {}", token); // 검증 실패 시 경고 로그 출력
+//        if (!validateToken(token, exchange)) {
+//            log.warn("Token validation failed for token: {}", token); // 검증 실패 시 경고 로그 출력
+//            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+//            return exchange.getResponse().setComplete();
+//        }
+//
+//        log.info("Token validation succeeded"); // 검증 성공 로그 출력
+//        return chain.filter(exchange); // 필터 체인을 통해 요청 전달
+        try {
+            // JWT 검증 및 헤더 추가
+            ServerWebExchange modifiedExchange = validateToken(token, exchange);
+            log.info("[토큰 검증 성공] header 확인 : {}", modifiedExchange.getRequest().getHeaders());
+
+            return chain.filter(modifiedExchange);
+        } catch (Exception e) {
+            log.warn("토큰 검증 실패] {}", e.getMessage());
             exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
             return exchange.getResponse().setComplete();
         }
-
-        log.info("Token validation succeeded"); // 검증 성공 로그 출력
-        return chain.filter(exchange); // 필터 체인을 통해 요청 전달
     }
 
     // Authorization 헤더에서 Bearer 토큰을 추출하는 메서드
@@ -72,7 +84,7 @@ public class LocalJwtAuthenticationFilter implements GlobalFilter {
     }
 
     // JWT 토큰을 검증하는 메서드
-    private boolean validateToken(String token, ServerWebExchange exchange) {
+    private ServerWebExchange validateToken(String token, ServerWebExchange exchange) {
         try {
             // Secret Key를 기반으로 HMAC-SHA 키 생성
             SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secretKey));
@@ -89,16 +101,20 @@ public class LocalJwtAuthenticationFilter implements GlobalFilter {
             log.info("Extracted Claims: {}", claims);
 
             // 헤더에 사용자 정보 추가
-            exchange.getRequest().mutate()
+            // 새로운 요청 객체 생성 및 헤더 추가
+            ServerHttpRequest modifiedRequest = exchange.getRequest().mutate()
                     .header("X-User-Id", claims.getSubject()) // 'sub' 필드 사용
                     .header("X-Role", claims.get("role").toString()) // 역할(Role)을 새로운 헤더에 추가
 //                    .header("X-Role", claims.get("auth").toString()) // 'auth' 필드 사용
                     .build();
 
-            return true; // 검증 성공
+//            return true; // 검증 성공
+            // 수정된 요청을 포함하는 ServerWebExchange 생성
+            return exchange.mutate().request(modifiedRequest).build();
         } catch (Exception e) {
             log.error("JWT validation error: {}", e.getMessage(), e);
-            return false; // 검증 실패
+//            return false; // 검증 실패
+            throw e; // 예외를 호출한 메서드로 전달
         }
     }
 

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/BaseEntity.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/BaseEntity.java
@@ -19,34 +19,34 @@ public class BaseEntity {
     @CreatedDate
     @Column(nullable = false, columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
-    private Long createdBy;
+    private String createdBy;
 
     @LastModifiedDate
     @Column(nullable = false, columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;
-    private Long updatedBy;
+    private String updatedBy;
 
     @Column(columnDefinition = "TIMESTAMP")
     private LocalDateTime deletedAt;
-    private Long deletedBy;
+    private String deletedBy;
 
     @Column(name = "is_deleted", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
     private boolean isDeleted = false;
 
-    protected BaseEntity(Long createdBy, Long updatedBy) {
+    protected BaseEntity(String createdBy, String updatedBy) {
         this.createdBy = createdBy;
         this.updatedBy = updatedBy;
     }
 
-    protected void createFrom(Long createdUserId) {
+    protected void createFrom(String createdUserId) {
         this.createdBy = createdUserId;
     }
 
-    protected void updateFrom(Long updatedUserId) {
+    protected void updateFrom(String updatedUserId) {
         this.updatedBy = updatedUserId;
     }
 
-    protected void deleteFrom(Long deletedUserId) {
+    protected void deleteFrom(String deletedUserId) {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
         this.deletedBy = deletedUserId;

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/exception/ErrorCode.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     HUB_ROUTE_ALREADY_EXIST(409, "HUB_ROUTE_ALREADY_EXIST", "이미 존재하는 허브 경로입니다."),
 
     // Path
+    PATH_ACCESS_DENIED(403, "PATH_ACCESS_DENIED", "최단 경로 조회에 접근할 수 없습니다."),
     PATH_NOT_EXIST(404, "PATH_NOT_EXIST", "존재하지 경로입니다."),
 
     // 외부 REST API

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/domain/Hub.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/domain/Hub.java
@@ -20,6 +20,6 @@ public class Hub implements Serializable {
     private HubStatus hubStatus;
     private HubCoordinate hubCoordinate;
     private HubAddress hubAddress;
-    private Long hubManagerId;
+    private String hubManagerId;
     private boolean isDeleted;
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/domain/HubForCreate.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/domain/HubForCreate.java
@@ -1,9 +1,9 @@
 package com.sparta.blackyolk.logistic_service.hub.application.domain;
 
 public record HubForCreate(
-    Long userId,
+    String userId,
     String role,
-    Long hubManagerId,
+    String hubManagerId,
     String name,
     String center,
     String sido,

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/domain/HubForDelete.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/domain/HubForDelete.java
@@ -1,7 +1,7 @@
 package com.sparta.blackyolk.logistic_service.hub.application.domain;
 
 public record HubForDelete(
-    Long userId,
+    String userId,
     String role,
     String hubId
 ) {

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/domain/HubForUpdate.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/domain/HubForUpdate.java
@@ -3,10 +3,10 @@ package com.sparta.blackyolk.logistic_service.hub.application.domain;
 import com.sparta.blackyolk.logistic_service.hub.data.vo.HubStatus;
 
 public record HubForUpdate(
-    Long userId,
+    String userId,
     String role,
     String hubId,
-    Long hubManagerId,
+    String hubManagerId,
     String name,
     HubStatus status,
     AddressForUpdateHub address

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/data/HubEntity.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/data/HubEntity.java
@@ -53,7 +53,7 @@ public class HubEntity extends BaseEntity {
     private HubAddressEmbeddable hubAddress;
 
     @Column(name = "user_id", nullable = false)
-    private Long hubManagerId;
+    private String hubManagerId;
 
     @PrePersist
     private void prePersistence() {
@@ -64,8 +64,8 @@ public class HubEntity extends BaseEntity {
 
     @Builder
     private HubEntity(
-        Long userId,
-        Long hubManagerId,
+        String userId,
+        String hubManagerId,
         String hubName,
         String hubCenter,
         HubCoordinateEmbeddable hubCoordinate,
@@ -140,7 +140,7 @@ public class HubEntity extends BaseEntity {
         }
     }
 
-    public void deleteHub(Long userId) {
+    public void deleteHub(String userId) {
         this.status = HubStatus.INACTIVE;
         super.deleteFrom(userId);
     }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/controller/HubCommandController.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/controller/HubCommandController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,21 +32,19 @@ public class HubCommandController {
 
     private final HubUseCase hubUseCase;
 
-    // TODO : 지우기
-    private final Long TEST_USER = 1L;
-    private final String TEST_ROLE = "MASTER";
-
-    // @PreAuthorize -> 이거 사용해보기
-
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public HubCreateResponse createHub(
-        @Valid @RequestBody HubCreateRequest hubCreateRequest
+        @Valid @RequestBody HubCreateRequest hubCreateRequest,
+        @RequestHeader(value = "X-User-Id", required = true) String userId,
+        @RequestHeader(value = "X-Role", required = true) String role
     ) {
-        // TODO : user token, user role 받기
+        log.info("[Hub 생성] header 확인: {}", userId);
+        log.info("[Hub 생성] header 확인: {}", role);
+
         HubForCreate hubForCreate = HubCreateRequest.toDomain(
-            TEST_USER,
-            TEST_ROLE,
+            userId,
+            role,
             hubCreateRequest
         );
 
@@ -56,12 +55,13 @@ public class HubCommandController {
     @PutMapping("/{hubId}")
     public HubUpdateResponse updateHub(
         @PathVariable(value = "hubId") String hubId,
-        @Valid @RequestBody HubUpdateRequest hubUpdateRequest
+        @Valid @RequestBody HubUpdateRequest hubUpdateRequest,
+        @RequestHeader(value = "X-User-Id", required = true) String userId,
+        @RequestHeader(value = "X-Role", required = true) String role
     ) {
-        // TODO : user token, user role 받기
         HubForUpdate hubForUpdate = HubUpdateRequest.toDomain(
-            TEST_USER,
-            TEST_ROLE,
+            userId,
+            role,
             hubId,
             hubUpdateRequest
         );
@@ -72,12 +72,13 @@ public class HubCommandController {
     @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/{hubId}")
     public HubDeleteResponse deleteHub(
-        @PathVariable(value = "hubId") String hubId
+        @PathVariable(value = "hubId") String hubId,
+        @RequestHeader(value = "X-User-Id", required = true) String userId,
+        @RequestHeader(value = "X-Role", required = true) String role
     ) {
-        // TODO : user token, user role 받기
         HubForDelete hubForDelete = new HubForDelete(
-            TEST_USER,
-            TEST_ROLE,
+            userId,
+            role,
             hubId
         );
         Hub hub = hubUseCase.deleteHub(hubForDelete);

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/controller/HubQueryController.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/controller/HubQueryController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -26,9 +27,10 @@ public class HubQueryController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{hubId}")
     public HubGetResponse getHub(
+        @RequestHeader(value = "X-User-Id", required = true) String userId,
+        @RequestHeader(value = "X-Role", required = true) String role,
         @PathVariable(value = "hubId") String hubId
     ) {
-        // TODO : user token, user role 받아야 하나?
         return hubCacheService.getHub(hubId);
     }
 
@@ -36,10 +38,11 @@ public class HubQueryController {
     @GetMapping
     @PaginationConstraint(defaultSort = "createdAt", defaultDirection = "DESC", availableSize = {10,30,50}, defaultSize = 10)
     public HubPageResponse getHubs(
+        @RequestHeader(value = "X-User-Id", required = true) String userId,
+        @RequestHeader(value = "X-Role", required = true) String role,
         Pageable pageable,
         @RequestParam(required = false) String keyword
     ) {
-        // TODO : user token, user role 받아야 하나?
         log.info("[Hub search 조회 pageable] : {}", pageable);
 
         return hubCacheService.getHubs(pageable, keyword);

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubCreateRequest.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubCreateRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 
 public record HubCreateRequest(
 
-    Long hubManagerId,
+    String hubManagerId,
 
     @NotBlank(message = "허브 명을 입력해주세요.")
     String name,
@@ -21,7 +21,7 @@ public record HubCreateRequest(
 ) {
 
     public static HubForCreate toDomain(
-        Long userId,
+        String userId,
         String role,
         HubCreateRequest hubCreateRequest
     ) {

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubCreateResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubCreateResponse.java
@@ -5,7 +5,7 @@ import com.sparta.blackyolk.logistic_service.hub.application.domain.Hub;
 
 public record HubCreateResponse(
     String id,
-    Long hubManagerId,
+    String hubManagerId,
     String name,
     String center,
     HubStatus status,

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubGetResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubGetResponse.java
@@ -5,7 +5,7 @@ import com.sparta.blackyolk.logistic_service.hub.data.vo.HubStatus;
 
 public record HubGetResponse(
     String id,
-    Long hubManagerId,
+    String hubManagerId,
     String name,
     String center,
     HubStatus status,

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubPageResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubPageResponse.java
@@ -26,7 +26,7 @@ public record HubPageResponse(
 
     public record HubResponse(
         String id,
-        Long hubManagerId,
+        String hubManagerId,
         String name,
         String center,
         HubStatus status,

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubUpdateRequest.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubUpdateRequest.java
@@ -5,14 +5,14 @@ import com.sparta.blackyolk.logistic_service.hub.application.domain.HubForUpdate
 import com.sparta.blackyolk.logistic_service.hub.data.vo.HubStatus;
 
 public record HubUpdateRequest(
-    Long hubManagerId,
+    String hubManagerId,
     String name,
     HubStatus status,
     HubAddressUpdateRequest address
 ) {
 
     public static HubForUpdate toDomain(
-        Long userId,
+        String userId,
         String role,
         String hubId,
         HubUpdateRequest hubUpdateRequest

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubUpdateResponse.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/dto/HubUpdateResponse.java
@@ -5,7 +5,7 @@ import com.sparta.blackyolk.logistic_service.hub.data.vo.HubStatus;
 
 public record HubUpdateResponse(
     String id,
-    Long hubManagerId,
+    String hubManagerId,
     String name,
     String center,
     HubStatus status,

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRouteForCreate.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRouteForCreate.java
@@ -1,7 +1,7 @@
 package com.sparta.blackyolk.logistic_service.hubroute.application.domain;
 
 public record HubRouteForCreate(
-    Long userId,
+    String userId,
     String role,
     String departureHubId,
     String arrivalHubId,

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRouteForDelete.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRouteForDelete.java
@@ -1,7 +1,7 @@
 package com.sparta.blackyolk.logistic_service.hubroute.application.domain;
 
 public record HubRouteForDelete(
-    Long userId,
+    String userId,
     String role,
     String departureHubId,
     String hubRouteId

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRouteForUpdate.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/domain/HubRouteForUpdate.java
@@ -3,7 +3,7 @@ package com.sparta.blackyolk.logistic_service.hubroute.application.domain;
 import com.sparta.blackyolk.logistic_service.hubroute.data.vo.HubRouteStatus;
 
 public record HubRouteForUpdate(
-    Long userId,
+    String userId,
     String role,
     String hubRouteId,
     String departureHubId, // timeslot이 없으면 null 처리를 할 수 있도록 Double로 설정,

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/port/HubRoutePersistencePort.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/port/HubRoutePersistencePort.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface HubRoutePersistencePort {
-    HubRoute createHubRoute(Long userId, HubRoute hubRoute);
+    HubRoute createHubRoute(String userId, HubRoute hubRoute);
     Optional<HubRoute> findByHubRouteId(String hubRouteId);
     HubRoute updateHubRoute(HubRouteForUpdate hubRouteForUpdate);
     HubRoute deleteHubRoute(HubRouteForDelete hubRouteForDelete);

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/service/HubRouteCacheService.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/service/HubRouteCacheService.java
@@ -55,7 +55,7 @@ public class HubRouteCacheService {
     }
 
     @CacheEvict(cacheNames = {"hub_route_page_cache", "hub_route_path_cache"}, allEntries = true)
-    public HubRouteCreateResponse createHubRoute(Long userId, HubRoute hubRoute) {
+    public HubRouteCreateResponse createHubRoute(String userId, HubRoute hubRoute) {
 
         log.info("[HubRoute 생성]: {}", hubRoute);
 

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/service/HubRoutePathService.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/service/HubRoutePathService.java
@@ -246,4 +246,10 @@ public class HubRoutePathService implements HubRoutePathUseCase {
         // 거리 계산
         return R * c; // 결과 거리 (단위: m)
     }
+
+    public void validateMaster(String role) {
+        if (!role.equals("MASTER")) {
+            throw new CustomException(ErrorCode.PATH_ACCESS_DENIED);
+        }
+    }
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/usecase/HubRoutePathUseCase.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/application/usecase/HubRoutePathUseCase.java
@@ -4,4 +4,5 @@ import com.sparta.blackyolk.logistic_service.hubroute.framework.web.dto.HubRoute
 
 public interface HubRoutePathUseCase {
     HubRoutePathResponse getShortestPath(String departure, String arrival, String currentTimeSlot);
+    void validateMaster(String role);
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/data/HubRouteEntity.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/data/HubRouteEntity.java
@@ -60,7 +60,7 @@ public class HubRouteEntity extends BaseEntity {
     }
 
     public HubRouteEntity(
-        Long userId,
+        String userId,
         HubEntity departureHub,
         HubEntity arrivalHub,
         Long duration,
@@ -75,7 +75,7 @@ public class HubRouteEntity extends BaseEntity {
     }
 
     public static HubRouteEntity toEntity(
-        Long userId,
+        String userId,
         HubEntity departureHubEntity,
         HubEntity arrivalHubEntity,
         HubRoute hubRoute
@@ -106,7 +106,7 @@ public class HubRouteEntity extends BaseEntity {
         Optional.ofNullable(hubRouteForUpdate.status()).ifPresent(value -> this.status = value);
     }
 
-    public void delete(Long userId) {
+    public void delete(String userId) {
         this.status = HubRouteStatus.INACTIVE;
         super.deleteFrom(userId);
     }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/adapter/HubRoutePersistenceAdapter.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/adapter/HubRoutePersistenceAdapter.java
@@ -65,7 +65,7 @@ public class HubRoutePersistenceAdapter implements HubRoutePersistencePort {
 
     @Transactional
     @Override
-    public HubRoute createHubRoute(Long userId, HubRoute hubRoute) {
+    public HubRoute createHubRoute(String userId, HubRoute hubRoute) {
 
         List<HubEntity> hubEntities = hubReadOnlyRepository.findByHubIdsAndIsDeletedFalse(
             List.of(hubRoute.getDepartureHub().getHubId(), hubRoute.getArrivalHub().getHubId())

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/controller/HubRouteCommandController.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/controller/HubRouteCommandController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,20 +32,17 @@ public class HubRouteCommandController {
 
     private final HubRouteUseCase hubRouteUseCase;
 
-    // TODO : 지우기
-    private final Long TEST_USER = 1L;
-    private final String TEST_ROLE = "MASTER";
-
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public HubRouteCreateResponse createHubRoute(
+        @RequestHeader(value = "X-User-Id", required = true) String userId,
+        @RequestHeader(value = "X-Role", required = true) String role,
         @PathVariable(value = "hubId") String hubId,
         @Valid @RequestBody HubRouteCreateRequest hubRouteCreateRequest
     ) {
-        // TODO : user token, user role 받기
         HubRouteForCreate hubRouteForCreate = HubRouteCreateRequest.toDomain(
-            TEST_USER,
-            TEST_ROLE,
+            userId,
+            role,
             hubId,
             hubRouteCreateRequest
         );
@@ -55,14 +53,15 @@ public class HubRouteCommandController {
     @ResponseStatus(HttpStatus.OK)
     @PutMapping("/{hubRouteId}")
     public HubRouteUpdateResponse updateHubRoute(
+        @RequestHeader(value = "X-User-Id", required = true) String userId,
+        @RequestHeader(value = "X-Role", required = true) String role,
         @PathVariable(value = "hubId") String hubId,
         @PathVariable(value = "hubRouteId") String hubRouteId,
         @Valid @RequestBody HubRouteUpdateRequest hubRouteUpdateRequest
     ) {
-        // TODO : user token, user role 받기
         HubRouteForUpdate hubRouteForUpdate = HubRouteUpdateRequest.toDomain(
-            TEST_USER,
-            TEST_ROLE,
+            userId,
+            role,
             hubId,
             hubRouteId,
             hubRouteUpdateRequest
@@ -74,13 +73,14 @@ public class HubRouteCommandController {
     @ResponseStatus(HttpStatus.OK)
     @DeleteMapping("/{hubRouteId}")
     public HubRouteDeleteResponse deleteResponse(
+        @RequestHeader(value = "X-User-Id", required = true) String userId,
+        @RequestHeader(value = "X-Role", required = true) String role,
         @PathVariable(value = "hubId") String hubId,
         @PathVariable(value = "hubRouteId") String hubRouteId
     ) {
-        // TODO : user token, user role 받기
         HubRouteForDelete hubRouteForDelete = new HubRouteForDelete(
-            TEST_USER,
-            TEST_ROLE,
+            userId,
+            role,
             hubId,
             hubRouteId
         );

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/controller/HubRoutePathQueryController.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/controller/HubRoutePathQueryController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -25,10 +26,14 @@ public class HubRoutePathQueryController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/shortest-path")
     public HubRoutePathResponse getShortestPath(
+        @RequestHeader(value = "X-User-Id", required = true) String userId,
+        @RequestHeader(value = "X-Role", required = true) String role,
         @RequestParam(value = "departure") String departure,
         @RequestParam(value = "arrival") String arrival
 
     ) {
+        hubRoutePathUseCase.validateMaster(role);
+
         LocalDateTime now = LocalDateTime.now();
         String currentTimeSlot = timeSlotWeightMapper.getCurrentTimeSlot(now);
 

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/controller/HubRouteQueryController.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/controller/HubRouteQueryController.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -29,10 +30,11 @@ public class HubRouteQueryController {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{hubRouteId}")
     public HubRouteGetResponse getHubRoute(
+        @RequestHeader(value = "X-User-Id", required = true) String userId,
+        @RequestHeader(value = "X-Role", required = true) String role,
         @PathVariable(value = "hubId") String hubId,
         @PathVariable(value = "hubRouteId") String hubRouteId
     ) {
-        // TODO : user token, user role 받아야 하나?
         HubRouteForRead hubRouteForRead = new HubRouteForRead(
             hubId,
             hubRouteId
@@ -45,11 +47,14 @@ public class HubRouteQueryController {
     @GetMapping
     @PaginationConstraint(defaultSort = "createdAt", defaultDirection = "DESC", availableSize = {10,30,50}, defaultSize = 10)
     public HubRoutePageResponse getHubRoutes(
+        @RequestHeader(value = "X-User-Id", required = true) String userId,
+        @RequestHeader(value = "X-Role", required = true) String role,
         @PathVariable(value = "hubId") String hubId,
         Pageable pageable,
         @RequestParam(required = false) String keyword
     ) {
-        // TODO : user token, user role 받아야 하나?
+        log.info("[HubRoute 목록 조회] userId: {}", userId);
+
         return hubRouteCacheService.getHubRoutes(hubId, pageable, keyword);
     }
 

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteCreateRequest.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteCreateRequest.java
@@ -14,7 +14,7 @@ public record HubRouteCreateRequest(
 ) {
 
     public static HubRouteForCreate toDomain(
-        Long userId,
+        String userId,
         String role,
         String hubId,
         HubRouteCreateRequest hubRouteCreateRequest

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteUpdateRequest.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hubroute/framework/web/dto/HubRouteUpdateRequest.java
@@ -9,7 +9,7 @@ public record HubRouteUpdateRequest(
 ) {
 
     public static HubRouteForUpdate toDomain(
-        Long userId,
+        String userId,
         String role,
         String departureHubId,
         String hubRouteId,


### PR DESCRIPTION
## 📝 작업 내용

> -  Hub 및 HubRoute에 userId 및 role header 추가 및 gateway filter를 수정합니다. 
>    - Hub 및 HubRoute에 userId 및 role header를 각각 추가하였습니다.
>      - 실제 서비스 로직에서 userId 와 role이 사용되지 않더라도, port로의 인증되지 않은 사용자의 직접적인 접근을 막고자, header를 모두 추가하였습니다. 
>    - gateway filter에서 header에 userId 와 role을 추가하지 않은 상태로 요청을 보내는 버그를 확인하여 수정하였습니다. 
>      - 요청 header에 userId 와 role을 추가하도록 변경하였습니다. 

## #️⃣ 연관 이슈
- #20

resolved: #20