### PR TITLE
[#64] Feign 통신 시 fallback 처리 및 재시도 로직 추가

### DIFF
--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/config/FeignConfig.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/config/FeignConfig.java
@@ -49,7 +49,7 @@ public class FeignConfig {
 
         public CustomRetryer() {
             // 실패한 요청에 대해 재시도 횟수 및 재시도 간 대기 시간 설정
-            super(100, 1000, 3);
+            super(1000, 1000, 3);
         }
 
         @Override

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/config/FeignConfig.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/config/FeignConfig.java
@@ -1,0 +1,67 @@
+package com.sparta.blackyolk.logistic_service.common.config;
+
+import com.sparta.blackyolk.logistic_service.common.exception.UserServiceException;
+import feign.Request;
+import feign.RetryableException;
+import feign.Retryer;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public Retryer retryer() {
+        return new CustomRetryer();
+    }
+
+    @Bean
+    public Request.Options options() {
+        return new Request.Options(
+            1000, // 연결 제한 시간 (1초)
+            2000  // 읽기 제한 시간 (2초)
+        );
+    }
+
+    @Bean
+    public feign.codec.ErrorDecoder errorDecoder() {
+        Map<Integer, String> errorMessages = Map.of(
+            400, "잘못된 요청입니다.",
+            401, "인증되지 않은 사용자입니다.",
+            403, "접근 권한이 없습니다.",
+            404, "요청한 리소스를 찾을 수 없습니다.",
+            503, "서비스를 사용할 수 없습니다. 잠시 후 다시 시도해주세요."
+        );
+
+        return (methodKey, response) -> {
+            log.error("Feign 호출 실패: HTTP 상태 코드 {}, 응답: {}", response.status(), response.body());
+
+            String message = errorMessages.getOrDefault(response.status(), "알 수 없는 오류가 발생했습니다.");
+            return new UserServiceException(response.status(), message);
+        };
+    }
+
+    public static class CustomRetryer extends Retryer.Default {
+        private int attempt = 1;
+
+        public CustomRetryer() {
+            // 실패한 요청에 대해 재시도 횟수 및 재시도 간 대기 시간 설정
+            super(100, 1000, 3);
+        }
+
+        @Override
+        public void continueOrPropagate(RetryableException e) {
+            log.warn("[Feign 재시도] 시도 횟수: {}, 이유: {}", attempt, e.getMessage());
+            attempt++;
+            super.continueOrPropagate(e); // 기본 동작 유지
+        }
+
+        @Override
+        public Retryer clone() {
+            return new CustomRetryer();
+        }
+    }
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/exception/ErrorCode.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/exception/ErrorCode.java
@@ -10,6 +10,8 @@ public enum ErrorCode {
     // 공통
     UNAUTHORIZED(401, "UNAUTHORIZED", "로그인을 해주세요."),
     FORBIDDEN(403, "USER_FORBIDDEN", "접근 권한이 없습니다."),
+    REQUEST_ACCEPTED(202, "REQUEST_ACCEPTED", "잠시만 기다려주세요."),
+    SERVICE_UNAVAILABLE(503, "SERVICE_UNAVAILABLE", "잠시후에 다시 요청해주세요."),
 
     // Hub
     HUB_BAD_REQUEST(400, "HUB_BAD_REQUEST", "잘못된 허브 요청입니다."),
@@ -41,7 +43,7 @@ public enum ErrorCode {
     RESOURCE_NOT_EXIST(404, "{RESOURCE}_NOT_EXIST", "클라이언트가 요청한 특정 리소스를 찾을 수 없는 경우"),
     RESOURCE_ALREADY_EXIST(409, "{RESOURCE}_ALREADY_EXIST", "클라이언트가 요청한 리소스가 이미 존재하는 경우"),
 
-    INTERNAL_SERVER_ERROR(500, "INTERNAL_SERVER_ERROR", "서버 오류"),
+    INTERNAL_SERVER_ERROR(500, "INTERNAL_SERVER_ERROR", "서버에 일시적인 오류가 발생했습니다."),
     CACHE_CONNECTION_ERROR(500, "CACHE_CONNECTION_ERROR", "캐시 오류");
 
     private final int code;

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/exception/UserServiceException.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/exception/UserServiceException.java
@@ -1,0 +1,9 @@
+package com.sparta.blackyolk.logistic_service.common.exception;
+
+import feign.FeignException;
+
+public class UserServiceException extends FeignException {
+    public UserServiceException(int code, String message) {
+        super(code, message);
+    }
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/fallback/UserClientFailTestFallbackFactory.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/fallback/UserClientFailTestFallbackFactory.java
@@ -1,0 +1,31 @@
+package com.sparta.blackyolk.logistic_service.common.fallback;
+
+import com.sparta.blackyolk.logistic_service.common.domain.UserResponseDto;
+import com.sparta.blackyolk.logistic_service.common.exception.ErrorCode;
+import com.sparta.blackyolk.logistic_service.common.exception.UserServiceException;
+import com.sparta.blackyolk.logistic_service.common.feignclient.UserFailTestClient;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.openfeign.FallbackFactory;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class UserClientFailTestFallbackFactory implements FallbackFactory<UserFailTestClient> {
+
+    @Override
+    public UserFailTestClient create(Throwable cause) {
+        return new UserFailTestClient() {
+
+            @Override
+            public Optional<UserResponseDto> getUser(String username, String authorization) {
+                log.error("[UserClientFailTestFallbackFactory 호출됨] 원인 : {}", cause.getMessage());
+
+                throw new UserServiceException(
+                    ErrorCode.SERVICE_UNAVAILABLE.getCode(),
+                    ErrorCode.SERVICE_UNAVAILABLE.getDetailMessage()
+                );
+            }
+        };
+    }
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/fallback/UserClientFallbackFactory.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/fallback/UserClientFallbackFactory.java
@@ -1,0 +1,31 @@
+package com.sparta.blackyolk.logistic_service.common.fallback;
+
+import com.sparta.blackyolk.logistic_service.common.domain.UserResponseDto;
+import com.sparta.blackyolk.logistic_service.common.exception.ErrorCode;
+import com.sparta.blackyolk.logistic_service.common.exception.UserServiceException;
+import com.sparta.blackyolk.logistic_service.common.feignclient.UserClient;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.openfeign.FallbackFactory;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class UserClientFallbackFactory implements FallbackFactory<UserClient> {
+
+    @Override
+    public UserClient create(Throwable cause) {
+        return new UserClient() {
+            @Override
+            public Optional<UserResponseDto> getUser(String username, String authorization) {
+
+                log.error("[[UserClientFallbackFactory 호출됨] : {}", cause.getMessage());
+
+                throw new UserServiceException(
+                    ErrorCode.SERVICE_UNAVAILABLE.getCode(),
+                    ErrorCode.SERVICE_UNAVAILABLE.getDetailMessage()
+                );
+            }
+        };
+    }
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/feignclient/UserClient.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/feignclient/UserClient.java
@@ -1,6 +1,8 @@
 package com.sparta.blackyolk.logistic_service.common.feignclient;
 
+import com.sparta.blackyolk.logistic_service.common.config.FeignConfig;
 import com.sparta.blackyolk.logistic_service.common.domain.UserResponseDto;
+import com.sparta.blackyolk.logistic_service.common.fallback.UserClientFallbackFactory;
 import com.sparta.blackyolk.logistic_service.common.service.UserService;
 import java.util.Optional;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -8,7 +10,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-@FeignClient(name = "auth-service")
+@FeignClient(
+    name = "auth-service",
+    fallbackFactory = UserClientFallbackFactory.class,
+    configuration = FeignConfig.class
+)
 public interface UserClient extends UserService {
 
     @GetMapping("/api/auth/users/{username}")
@@ -16,5 +22,4 @@ public interface UserClient extends UserService {
         @PathVariable(value = "username") String username,
         @RequestHeader(value = "Authorization") String authorization
     );
-
 }

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/feignclient/UserFailTestClient.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/common/feignclient/UserFailTestClient.java
@@ -1,0 +1,25 @@
+package com.sparta.blackyolk.logistic_service.common.feignclient;
+
+import com.sparta.blackyolk.logistic_service.common.config.FeignConfig;
+import com.sparta.blackyolk.logistic_service.common.domain.UserResponseDto;
+import com.sparta.blackyolk.logistic_service.common.fallback.UserClientFallbackFactory;
+import java.util.Optional;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(
+    name = "auth-service-fail-test",
+    fallbackFactory = UserClientFallbackFactory.class,
+    url = "http://invalid-url",
+    configuration = FeignConfig.class
+)
+public interface UserFailTestClient {
+
+    @GetMapping("/api/auth/users/{username}")
+    Optional<UserResponseDto> getUser(
+        @PathVariable(value = "username") String username,
+        @RequestHeader(value = "Authorization") String authorization
+    );
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/service/HubFailService.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/service/HubFailService.java
@@ -1,0 +1,50 @@
+package com.sparta.blackyolk.logistic_service.hub.application.service;
+
+import com.sparta.blackyolk.logistic_service.common.exception.ErrorCode;
+import com.sparta.blackyolk.logistic_service.common.exception.UserServiceException;
+import com.sparta.blackyolk.logistic_service.common.feignclient.UserFailTestClient;
+import com.sparta.blackyolk.logistic_service.hub.application.usecase.HubFailUseCase;
+import feign.RetryableException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HubFailService implements HubFailUseCase {
+
+    private final UserFailTestClient userFailTestClient;
+
+    private static final String INVALID_USER = "invalid_user";
+    private static final String INVALID_TOKEN = "invalid_token";
+
+    public void handleFailCase() {
+        log.info("[Hub 생성] Fail 케이스 실행");
+
+        try {
+            log.info("[Feign 호출] 사용자 정보 조회 실패 테스트 시작");
+            // Feign 클라이언트를 호출해 RetryableException 발생 유도
+            feignClientCall();
+        } catch (RetryableException e) {
+            log.error("[Feign 호출] 요청 실패 (RetryableException): {}", e.getMessage(), e);
+            throw e; // 재시도를 위해 예외를 던짐
+        } catch (Exception e) {
+            log.error("[Feign 호출] 요청 실패: {}", e.getMessage(), e);
+            sendFallbackNotification(e);
+        }
+    }
+
+    private void feignClientCall() {
+        log.info("[Feign 호출] 의도적으로 RetryableException 발생");
+        userFailTestClient.getUser(INVALID_USER, INVALID_TOKEN);
+    }
+
+    private void sendFallbackNotification(Exception e) {
+        log.error("[Hub 생성] Fallback 처리");
+        throw new UserServiceException(
+            ErrorCode.SERVICE_UNAVAILABLE.getCode(),
+            ErrorCode.SERVICE_UNAVAILABLE.getDetailMessage()
+        );
+    }
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/service/HubService.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/service/HubService.java
@@ -4,6 +4,7 @@ import com.sparta.blackyolk.logistic_service.common.domain.UserResponseDto;
 import com.sparta.blackyolk.logistic_service.common.domain.vo.UserRoleEnum;
 import com.sparta.blackyolk.logistic_service.common.exception.CustomException;
 import com.sparta.blackyolk.logistic_service.common.exception.ErrorCode;
+import com.sparta.blackyolk.logistic_service.common.exception.UserServiceException;
 import com.sparta.blackyolk.logistic_service.common.service.UserService;
 import com.sparta.blackyolk.logistic_service.hub.application.domain.Hub;
 import com.sparta.blackyolk.logistic_service.hub.application.domain.HubForCreate;
@@ -110,15 +111,21 @@ public class HubService implements HubUseCase {
 
     private void validateHubManagerId(String hubManagerId, String authorization) {
 
-        log.info("[Hub 생성] authorization 확인: {}", authorization);
+        log.info("[Hub 생성] 사용자 인증 및 권한 확인 시작");
 
-        UserResponseDto user = userService.getUser(hubManagerId, authorization).orElseThrow(
-            () -> new CustomException(ErrorCode.USER_NOT_EXIST)
-        );
+        try {
+            UserResponseDto user = userService.getUser(hubManagerId, authorization)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_EXIST));
 
-        if (!user.getRole().equals(UserRoleEnum.HUB_ADMIN)) {
-            log.info("[Hub 생성] user role 확인: {}", user.getRole());
-            throw new CustomException(ErrorCode.USER_BAD_REQUEST, "HUB_ADMIN 권한의 사용자가 아닙니다.");
+            log.info("[Hub 생성] 사용자 role 확인: {}", user.getRole());
+
+            if (!UserRoleEnum.HUB_ADMIN.equals(user.getRole())) {
+                throw new CustomException(ErrorCode.USER_BAD_REQUEST, "HUB_ADMIN 권한의 사용자가 아닙니다.");
+            }
+
+        } catch (UserServiceException e) {
+            log.error("[Hub 생성] UserServiceException 발생: {}", e.getMessage(), e);
+            throw e;
         }
     }
 

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/usecase/HubFailUseCase.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/application/usecase/HubFailUseCase.java
@@ -1,0 +1,5 @@
+package com.sparta.blackyolk.logistic_service.hub.application.usecase;
+
+public interface HubFailUseCase {
+    void handleFailCase();
+}

--- a/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/controller/HubCommandController.java
+++ b/logistic-service/src/main/java/com/sparta/blackyolk/logistic_service/hub/framework/web/controller/HubCommandController.java
@@ -4,6 +4,7 @@ import com.sparta.blackyolk.logistic_service.hub.application.domain.Hub;
 import com.sparta.blackyolk.logistic_service.hub.application.domain.HubForCreate;
 import com.sparta.blackyolk.logistic_service.hub.application.domain.HubForDelete;
 import com.sparta.blackyolk.logistic_service.hub.application.domain.HubForUpdate;
+import com.sparta.blackyolk.logistic_service.hub.application.usecase.HubFailUseCase;
 import com.sparta.blackyolk.logistic_service.hub.application.usecase.HubUseCase;
 import com.sparta.blackyolk.logistic_service.hub.framework.web.dto.HubCreateRequest;
 import com.sparta.blackyolk.logistic_service.hub.framework.web.dto.HubCreateResponse;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class HubCommandController {
 
     private final HubUseCase hubUseCase;
+    private final HubFailUseCase hubFailUseCase;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
@@ -38,10 +41,15 @@ public class HubCommandController {
         @Valid @RequestBody HubCreateRequest hubCreateRequest,
         @RequestHeader(value = "X-User-Id", required = true) String userId,
         @RequestHeader(value = "X-Role", required = true) String role,
-        @RequestHeader(value = "Authorization", required = true) String authorization
+        @RequestHeader(value = "Authorization", required = true) String authorization,
+        @RequestParam(value = "fail", required = false, defaultValue = "false") boolean fail
     ) {
         log.info("[Hub 생성] header 확인: {}", userId);
         log.info("[Hub 생성] header 확인: {}", role);
+
+        if (fail) {
+            hubFailUseCase.handleFailCase();
+        }
 
         HubForCreate hubForCreate = HubCreateRequest.toDomain(
             userId,

--- a/logistic-service/src/main/resources/application-dev.yml
+++ b/logistic-service/src/main/resources/application-dev.yml
@@ -43,6 +43,8 @@ spring:
 
 logging:
   level:
+    root: INFO
+    com.your.package.FeignConfig: WARN
     org.hibernate: WARN
     org.springframework.cache: DEBUG
     org.springframework.data.redis: DEBUG
@@ -57,3 +59,12 @@ naver:
   drive-url: https://naveropenapi.apigw.ntruss.com/map-direction/v1/driving
   rest-api-key-id: ${X-NCP-APIGW-API-KEY-ID}
   rest-api-key: ${X-NCP-APIGW-API-KEY}
+
+feign:
+  client:
+    config:
+      default:
+        retryer: true # 재시도 활성화
+        requestOptions:
+          connectTimeout: 1000 # 연결 제한 시간
+          readTimeout: 2000    # 읽기 제한 시간


### PR DESCRIPTION
## 📝 작업 내용

> -  Hub에서 Auth 서비스로 통신을 시도할 때, Feign 통신에 실패하게 되는 경우 fallback 처리 및 재시도 로직을 추가합니다. 
>    - fallback의 기본 응답은 `잠시후에 다시 요청해주세요.` 입니다. 
>    - 재시도는 매번 1초 대기, 최대 3회 재시도 합니다. 
>      `POST /api/hubs?fail=true` 의 실패 테스트 엔드포인트 에서 재시도 로직과 fallback 테스트를 해보실 수 있습니다. 

## #️⃣ 연관 이슈
- #64

resolved: #64